### PR TITLE
impl a function to parse chunk sizes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "httparse"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Sean McArthur <sean.monstar@gmail.com>"]
 license = "MIT"
 description = "A tiny, safe, speedy, zero-copy HTTP/1.x parser."


### PR DESCRIPTION
All HTTP/1.1 clients and servers must understand the chunked encoding
and therefore must parse chunk sizes. The `parse_chunk_size` function
uses relies on the internals of httparse so it can't be implemented as
easily in an external crate. It is based on hypers implementation but
unlike hyper it operates on &[u8] and returns partial if the chunk size
is incomplete. For this reason it is more suitable for async HTTP code.

This is a breaking change because it adds a new variant to the Error
enum.