### PR TITLE
Add dynamic headers support

### DIFF
--- a/tests/uri.rs
+++ b/tests/uri.rs
@@ -1,6 +1,6 @@
 extern crate httparse;
 
-use httparse::{Error, Request, Status, EMPTY_HEADER};
+use httparse::{Error, Request, DynRequest, Status, EMPTY_HEADER};
 
 const NUM_OF_HEADERS: usize = 4;
 
@@ -23,9 +23,39 @@ macro_rules! req {
     }
     )
 }
+macro_rules! req_dyn {
+    ($name:ident, $buf:expr, |$arg:ident| $body:expr) => (
+        req_dyn! {$name, $buf, Ok(Status::Complete($buf.len())), |$arg| $body }
+    );
+    ($name:ident, $buf:expr, $len:expr, |$arg:ident| $body:expr) => (
+    #[test]
+    fn $name() {
+        let mut req = DynRequest::new(None);
+        let status = req.parse($buf.as_ref());
+        assert_eq!(status, $len);
+        closure(req.get_request($buf.as_ref()));
+
+        fn closure($arg: Request) {
+            $body
+        }
+    }
+    )
+}
 
 req! {
     urltest_001,
+    b"GET /bar;par?b HTTP/1.1\r\nHost: foo\r\n\r\n",
+    |req| {
+        assert_eq!(req.method.unwrap(), "GET");
+        assert_eq!(req.path.unwrap(), "/bar;par?b");
+        assert_eq!(req.version.unwrap(), 1);
+        assert_eq!(req.headers.len(), 1);
+        assert_eq!(req.headers[0].name, "Host");
+        assert_eq!(req.headers[0].value, b"foo");
+    }
+}
+req_dyn! {
+    urltest_001_dyn,
     b"GET /bar;par?b HTTP/1.1\r\nHost: foo\r\n\r\n",
     |req| {
         assert_eq!(req.method.unwrap(), "GET");


### PR DESCRIPTION
This work is an experimential support for a better API in regards to #18 .

The design is not yet ideal: it requires the user to call `get_request` on the same buffer as the `parse` call. But it works.

Now we can write

```rust
let buf = b"GET /404 HTTP/1.1\r\nHost:";
let mut req = httparse::DynRequest::new(None);
let res = req.parse(buf).unwrap();
if res.is_partial() {
    // get a snapshot with statically allocated headers
    let req = req.get_request(buf);
    match req.path {
        Some(ref path) => {
            // check router for path.
            // /404 doesn't exist? we could stop parsing
        },
        None => {
            // must read more and parse again
        }
    }
}
```
without knowing or predict in advance how many headers there can be. The cost is a `Vec` allocation, and predicting capacity is possible (pass `Some(capacity)` rather than `None` to `DynRequest::new`.