### PR TITLE
Make the Error::description_str public.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,8 +162,9 @@ pub enum Error {
 }
 
 impl Error {
+    /// Description of the parsing error.
     #[inline]
-    fn description_str(&self) -> &'static str {
+    pub fn description_str(&self) -> &'static str {
         match *self {
             Error::HeaderName => "invalid header name",
             Error::HeaderValue => "invalid header value",


### PR DESCRIPTION
This will make it easier to wrap the parse error in another error. Right now to achieve this you have to do something like
```rust
pub enum Error {
    AnotherError,
    ParseError(httparse::Error),
}

impl Display for Error {
    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
        let message = match self {
            AnotherError => String::from("MESSAGE"),
            Error::ParseError(e) => format!("{}", e),
...
```
By going through the Display trait we have to allocate a new String and copy the static error message into it.
If we had access to the `&'static str` error description the match above would be much simpler and will have no need for allocations.

```rust
AnotherError => "MESSAGE",
Error::ParseError(e) => e.description_str(),
```