### PR TITLE
Set specific version of pico-sys in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ default = ["std"]
 std = []
 
 [dev-dependencies]
-pico-sys = "0.0"
+pico-sys = "0.0.1"
 
 [profile.bench]
 lto = true


### PR DESCRIPTION
Using a dependency with required version 0.0 can cause issues with semver as updates are not guaranteed to be backwards compatible.