### PR TITLE
Fix off-by-one error

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -64,7 +64,7 @@ impl<'a> Bytes<'a> {
 
     #[inline]
     pub fn next_8<'b>(&'b mut self) -> Option<Bytes8<'b, 'a>> {
-        if self.slice.len() > self.pos + 8 {
+        if self.slice.len() >= self.pos + 8 {
             Some(Bytes8::new(self))
         } else {
             None

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -154,3 +154,63 @@ impl<'a, 'b: 'a> Bytes8<'a, 'b> {
         self.pos += 1;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Bytes;
+
+    #[test]
+    fn test_next_8_too_short() {
+        // Start with 10 bytes.
+        let slice = [0u8, 1u8, 2u8, 3u8, 4u8, 5u8, 6u8, 7u8, 8u8, 9u8];
+        let mut bytes = Bytes::new(&slice);
+        // Skip 3 of them.
+        unsafe { bytes.advance(3); }
+        // There should be 7 left, not enough to call next_8.
+        assert!(bytes.next_8().is_none());
+    }
+
+    #[test]
+    fn test_next_8_just_right() {
+        // Start with 10 bytes.
+        let slice = [0u8, 1u8, 2u8, 3u8, 4u8, 5u8, 6u8, 7u8, 8u8, 9u8];
+        let mut bytes = Bytes::new(&slice);
+        // Skip 2 of them.
+        unsafe { bytes.advance(2); }
+        // There should be 8 left, just enough to call next_8.
+        let ret = bytes.next_8();
+        assert!(ret.is_some());
+        let mut ret = ret.unwrap();
+        // They should be the bytes starting with 2.
+        assert_eq!(ret._0(), 2u8);
+        assert_eq!(ret._1(), 3u8);
+        assert_eq!(ret._2(), 4u8);
+        assert_eq!(ret._3(), 5u8);
+        assert_eq!(ret._4(), 6u8);
+        assert_eq!(ret._5(), 7u8);
+        assert_eq!(ret._6(), 8u8);
+        assert_eq!(ret._7(), 9u8);
+    }
+
+    #[test]
+    fn test_next_8_extra() {
+        // Start with 10 bytes.
+        let slice = [0u8, 1u8, 2u8, 3u8, 4u8, 5u8, 6u8, 7u8, 8u8, 9u8];
+        let mut bytes = Bytes::new(&slice);
+        // Skip 1 of them.
+        unsafe { bytes.advance(1); }
+        // There should be 9 left, more than enough to call next_8.
+        let ret = bytes.next_8();
+        assert!(ret.is_some());
+        let mut ret = ret.unwrap();
+        // They should be the bytes starting with 1.
+        assert_eq!(ret._0(), 1u8);
+        assert_eq!(ret._1(), 2u8);
+        assert_eq!(ret._2(), 3u8);
+        assert_eq!(ret._3(), 4u8);
+        assert_eq!(ret._4(), 5u8);
+        assert_eq!(ret._5(), 6u8);
+        assert_eq!(ret._6(), 7u8);
+        assert_eq!(ret._7(), 8u8);
+    }
+}


### PR DESCRIPTION
If len = pos + 8, then there are exactly eight bytes available.