### PR TITLE
Add missing Eq derivations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,7 +212,7 @@ pub type Result<T> = result::Result<Status<T>, Error>;
 /// `Complete` is used when the buffer contained the complete value.
 /// `Partial` is used when parsing did not reach the end of the expected value,
 /// but no invalid data was found.
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum Status<T> {
     /// The completed result.
     Complete(T),
@@ -275,7 +275,7 @@ impl<T> Status<T> {
 ///     }
 /// }
 /// ```
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct Request<'headers, 'buf: 'headers> {
     /// The request method, such as `GET`.
     pub method: Option<&'buf str>,
@@ -342,7 +342,7 @@ fn skip_empty_lines(bytes: &mut Bytes) -> Result<()> {
 /// A parsed Response.
 ///
 /// See `Request` docs for explanation of optional values.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct Response<'headers, 'buf: 'headers> {
     /// The response version, such as `HTTP/1.1`.
     pub version: Option<u8>,
@@ -407,7 +407,7 @@ impl<'h, 'b> Response<'h, 'b> {
 }
 
 /// Represents a parsed header.
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub struct Header<'a> {
     /// The name portion of a header.
     ///


### PR DESCRIPTION
The derivation on Header is correct because comparisons of string slices and byte slices meet the requirements. The derivations on Request and Response are correct because they contain only string slices, byte slices, slices of Header objects (which are now Eq), primitives, and options (which are Eq if their contents are). Finally the derivation on Status is correct because #[derive(Eq)] on a generic only actually implements Eq if all generic parameters are Eq, which for Status is sufficient.