### PR TITLE
Basic fuzzing using cargo-fuzz

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,38 @@
+
+[package]
+name = "httparse-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.3"
+
+[dependencies.httparse]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "parse_request"
+path = "fuzz_targets/parse_request.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "parse_chunk_size"
+path = "fuzz_targets/parse_chunk_size.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "parse_headers"
+path = "fuzz_targets/parse_headers.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/parse_chunk_size.rs
+++ b/fuzz/fuzz_targets/parse_chunk_size.rs
@@ -1,0 +1,6 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    httparse::parse_chunk_size(data);
+});

--- a/fuzz/fuzz_targets/parse_headers.rs
+++ b/fuzz/fuzz_targets/parse_headers.rs
@@ -1,0 +1,7 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let mut headers = [httparse::EMPTY_HEADER; 16];
+    httparse::parse_headers(data, &mut headers);
+});

--- a/fuzz/fuzz_targets/parse_request.rs
+++ b/fuzz/fuzz_targets/parse_request.rs
@@ -1,0 +1,8 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let mut headers = [httparse::EMPTY_HEADER; 16];
+    let mut req = httparse::Request::new(&mut headers);
+    req.parse(data);
+});


### PR DESCRIPTION
Reading https://lobste.rs/s/bfjdfd/rust_curl_with_hyper#c_r8wiua made me curious to do some basic fuzzing on this crate using `cargo-fuzz`. None of the included targets found anything interesting though, which is good. Perhaps we should try to target the SIMD code directly, by exposing it publicly with a `fuzzing` feature or something like that?