### PR TITLE
Describe return of parse function.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -300,6 +300,8 @@ impl<'h, 'b> Request<'h, 'b> {
     }
 
     /// Try to parse a buffer of bytes into the Request.
+    /// 
+    /// Returns byte offset in `buf` to start of HTTP body.
     pub fn parse(&mut self, buf: &'b [u8]) -> Result<usize> {
         let orig_len = buf.len();
         let mut bytes = Bytes::new(buf);


### PR DESCRIPTION
Just a doc comment so people don't have to read through parse's implementation to know what its return value is.