### PR TITLE
Fix up some deprecations

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -135,7 +135,7 @@ impl Version {
             }
             num.push(c);
         }
-        let major = try!(num.parse::<u32>().map_err(|e| e.to_string()));
+        let major = num.parse::<u32>().map_err(|e| e.to_string())?;
 
         num.clear();
         for c in parts[1].chars() {
@@ -144,7 +144,7 @@ impl Version {
             }
             num.push(c);
         }
-        let minor = try!(num.parse::<u32>().map_err(|e| e.to_string()));
+        let minor = num.parse::<u32>().map_err(|e| e.to_string())?;
 
         num.clear();
         for c in parts[2].chars() {
@@ -153,7 +153,7 @@ impl Version {
             }
             num.push(c);
         }
-        let patch = try!(num.parse::<u32>().map_err(|e| e.to_string()));
+        let patch = num.parse::<u32>().map_err(|e| e.to_string())?;
 
         Ok(Version {
             major: major,

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,11 @@
 use std::env;
-use std::ffi::OsString;
-use std::process::Command;
+//use std::ffi::OsString;
+//use std::process::Command;
 
 fn main() {
+    // We don't currently need to check the Version anymore...
+    // But leaving this in place in case we need to in the future.
+    /*
     let rustc = env::var_os("RUSTC").unwrap_or(OsString::from("rustc"));
     let output = Command::new(&rustc)
         .arg("--version")
@@ -12,11 +15,13 @@ fn main() {
 
     let version = String::from_utf8(output)
         .expect("rustc version output should be utf-8");
+    */
 
-    enable_new_features(&version);
+    enable_new_features(/*&version*/);
 }
 
-fn enable_new_features(raw_version: &str) {
+fn enable_new_features(/*raw_version: &str*/) {
+    /*
     let version = match Version::parse(raw_version) {
         Ok(version) => version,
         Err(err) => {
@@ -24,21 +29,12 @@ fn enable_new_features(raw_version: &str) {
             return;
         }
     };
+    */
 
-    let min_rust2018_version = Version {
-        major: 1,
-        minor: 31,
-        patch: 0,
-    };
-
-    if version >= min_rust2018_version {
-        println!("cargo:rustc-cfg=httparse_min_2018");
-    }
-
-    enable_simd(version);
+    enable_simd(/*version*/);
 }
 
-fn enable_simd(version: Version) {
+fn enable_simd(/*version: Version*/) {
     if env::var_os("CARGO_FEATURE_STD").is_none() {
         println!("cargo:warning=building for no_std disables httparse SIMD");
         return;
@@ -50,15 +46,7 @@ fn enable_simd(version: Version) {
         return;
     }
 
-    let min_simd_version = Version {
-        major: 1,
-        minor: 27,
-        patch: 0,
-    };
-
-    if version >= min_simd_version {
-        println!("cargo:rustc-cfg=httparse_simd");
-    }
+    println!("cargo:rustc-cfg=httparse_simd");
 
     // cfg(target_feature) isn't stable yet, but CARGO_CFG_TARGET_FEATURE has
     // a list... We aren't doing anything unsafe, since the is_x86_feature_detected
@@ -109,6 +97,7 @@ fn enable_simd(version: Version) {
     }
 }
 
+/*
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 struct Version {
     major: u32,
@@ -162,6 +151,7 @@ impl Version {
         })
     }
 }
+*/
 
 fn var_is(key: &str, val: &str) -> bool {
     match env::var(key) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(missing_docs)]
 #![cfg_attr(test, deny(warnings))]
-#![cfg_attr(httparse_min_2018, allow(rust_2018_idioms))]
 
 //! # httparse
 //!
@@ -630,9 +629,9 @@ fn parse_uri<'a>(bytes: &mut Bytes<'a>) -> Result<&'a str> {
 
 #[inline]
 fn parse_code(bytes: &mut Bytes) -> Result<u16> {
-    let hundreds = expect!(bytes.next() == b'0'...b'9' => Err(Error::Status));
-    let tens = expect!(bytes.next() == b'0'...b'9' => Err(Error::Status));
-    let ones = expect!(bytes.next() == b'0'...b'9' => Err(Error::Status));
+    let hundreds = expect!(bytes.next() == b'0'..=b'9' => Err(Error::Status));
+    let tens = expect!(bytes.next() == b'0'..=b'9' => Err(Error::Status));
+    let ones = expect!(bytes.next() == b'0'..=b'9' => Err(Error::Status));
 
     Ok(Status::Complete((hundreds - b'0') as u16 * 100 +
         (tens - b'0') as u16 * 10 +
@@ -901,7 +900,7 @@ pub fn parse_chunk_size(buf: &[u8])
     loop {
         let b = next!(bytes);
         match b {
-            b'0' ... b'9' if in_chunk_size => {
+            b'0' ..= b'9' if in_chunk_size => {
                 if count > 15 {
                     return Err(InvalidChunkSize);
                 }
@@ -909,7 +908,7 @@ pub fn parse_chunk_size(buf: &[u8])
                 size *= RADIX;
                 size += (b - b'0') as u64;
             },
-            b'a' ... b'f' if in_chunk_size => {
+            b'a' ..= b'f' if in_chunk_size => {
                 if count > 15 {
                     return Err(InvalidChunkSize);
                 }
@@ -917,7 +916,7 @@ pub fn parse_chunk_size(buf: &[u8])
                 size *= RADIX;
                 size += (b + 10 - b'a') as u64;
             }
-            b'A' ... b'F' if in_chunk_size => {
+            b'A' ..= b'F' if in_chunk_size => {
                 if count > 15 {
                     return Err(InvalidChunkSize);
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(missing_docs)]
 #![cfg_attr(test, deny(warnings))]
-// we can't upgrade while supporting Rust 1.3
-#![allow(deprecated)]
 #![cfg_attr(httparse_min_2018, allow(rust_2018_idioms))]
 
 //! # httparse
@@ -1365,14 +1363,5 @@ mod tests {
         assert_eq!(parse_chunk_size(b"1ffffffffffffffff\r\n"), Err(::InvalidChunkSize));
         assert_eq!(parse_chunk_size(b"Affffffffffffffff\r\n"), Err(::InvalidChunkSize));
         assert_eq!(parse_chunk_size(b"fffffffffffffffff\r\n"), Err(::InvalidChunkSize));
-    }
-
-    #[cfg(feature = "std")]
-    #[test]
-    fn test_std_error() {
-        use super::Error;
-        use std::error::Error as StdError;
-        let err = Error::HeaderName;
-        assert_eq!(err.to_string(), err.description());
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -23,7 +23,7 @@ macro_rules! expect {
 
 macro_rules! complete {
     ($e:expr) => {
-        match try!($e) {
+        match $e? {
             Status::Complete(v) => v,
             Status::Partial => return Ok(Status::Partial)
         }

--- a/src/simd/mod.rs
+++ b/src/simd/mod.rs
@@ -89,9 +89,9 @@ mod runtime {
     //! at least in 1.27.0, the functions don't inline, leaving using it
     //! actually *slower* than just using the scalar fallback.
 
-    use core::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
+    use core::sync::atomic::{AtomicUsize, Ordering};
 
-    static FEATURE: AtomicUsize = ATOMIC_USIZE_INIT;
+    static FEATURE: AtomicUsize = AtomicUsize::new(0);
 
     const INIT: usize = 0;
 


### PR DESCRIPTION
Now that we require at least Rust 1.36, we can fix up some deprecations.