### PR TITLE
Fix clippy warnings for Rust 1.59

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -9,7 +9,7 @@ impl<'a> Bytes<'a> {
     #[inline]
     pub fn new(slice: &'a [u8]) -> Bytes<'a> {
         Bytes {
-            slice: slice,
+            slice,
             pos: 0
         }
     }
@@ -26,7 +26,7 @@ impl<'a> Bytes<'a> {
 
     #[inline]
     pub unsafe fn bump(&mut self) {
-        debug_assert!(self.pos + 1 <= self.slice.len(), "overflow");
+        debug_assert!(self.pos < self.slice.len(), "overflow");
         self.pos += 1;
     }
 
@@ -56,7 +56,7 @@ impl<'a> Bytes<'a> {
         let head_pos = self.pos - skip;
         let ptr = self.slice.as_ptr();
         let head = slice::from_raw_parts(ptr, head_pos);
-        let tail = slice::from_raw_parts(ptr.offset(self.pos as isize), self.slice.len() - self.pos);
+        let tail = slice::from_raw_parts(ptr.add(self.pos), self.slice.len() - self.pos);
         self.pos = 0;
         self.slice = tail;
         head
@@ -137,7 +137,7 @@ impl<'a, 'b: 'a> Bytes8<'a, 'b> {
     #[inline]
     fn new(bytes: &'a mut Bytes<'b>) -> Bytes8<'a, 'b> {
         Bytes8 {
-            bytes: bytes,
+            bytes,
             pos: 0,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -358,7 +358,7 @@ impl<'h, 'b> Request<'h, 'b> {
             method: None,
             path: None,
             version: None,
-            headers: headers,
+            headers,
         }
     }
 
@@ -461,7 +461,7 @@ impl<'h, 'b> Response<'h, 'b> {
             version: None,
             code: None,
             reason: None,
-            headers: headers,
+            headers,
         }
     }
 
@@ -650,7 +650,7 @@ fn parse_reason<'a>(bytes: &mut Bytes<'a>) -> Result<&'a str> {
                     ""
                 }
             }));
-        } else if !(b == 0x09 || b == b' ' || (b >= 0x21 && b <= 0x7E) || b >= 0x80) {
+        } else if !(b == 0x09 || b == b' ' || (0x21..=0x7E).contains(&b) || b >= 0x80) {
             return Err(Error::Status);
         } else if b >= 0x80 {
             seen_obs_text = true;
@@ -748,7 +748,7 @@ unsafe fn deinit_slice_mut<'a, 'b, T>(s: &'a mut &'b mut [T]) -> &'a mut &'b mut
     let s = s as *mut &mut [MaybeUninit<T>];
     &mut *s
 }
-unsafe fn assume_init_slice<'a, T>(s: &'a mut [MaybeUninit<T>]) -> &'a mut [T] {
+unsafe fn assume_init_slice<T>(s: &mut [MaybeUninit<T>]) -> &mut [T] {
     let s: *mut [MaybeUninit<T>] = s;
     let s = s as *mut [T];
     &mut *s

--- a/src/simd/avx2.rs
+++ b/src/simd/avx2.rs
@@ -8,7 +8,7 @@ pub enum Scan {
 }
 
 
-pub unsafe fn parse_uri_batch_32<'a>(bytes: &mut Bytes<'a>) -> Scan {
+pub unsafe fn parse_uri_batch_32(bytes: &mut Bytes) -> Scan {
     while bytes.as_ref().len() >= 32 {
         let advance = match_url_char_32_avx(bytes.as_ref());
         bytes.advance(advance);
@@ -59,7 +59,7 @@ unsafe fn match_url_char_32_avx(buf: &[u8]) -> usize {
     let bits = _mm256_and_si256(_mm256_shuffle_epi8(ARF, cols), rbms);
 
     let v = _mm256_cmpeq_epi8(bits, _mm256_setzero_si256());
-    let r = 0xffffffff_00000000 | _mm256_movemask_epi8(v) as u64;
+    let r = 0xffff_ffff_0000_0000 | _mm256_movemask_epi8(v) as u64;
 
     _tzcnt_u64(r) as usize
 }
@@ -109,7 +109,7 @@ unsafe fn match_header_value_char_32_avx(buf: &[u8]) -> usize {
     let del = _mm256_cmpeq_epi8(dat, DEL);
     let bit = _mm256_andnot_si256(del, _mm256_or_si256(low, tab));
     let rev = _mm256_cmpeq_epi8(bit, _mm256_setzero_si256());
-    let res = 0xffffffff_00000000 | _mm256_movemask_epi8(rev) as u64;
+    let res = 0xffff_ffff_0000_0000 | _mm256_movemask_epi8(rev) as u64;
 
     _tzcnt_u64(res) as usize
 }

--- a/src/simd/sse42.rs
+++ b/src/simd/sse42.rs
@@ -1,6 +1,6 @@
 use ::iter::Bytes;
 
-pub unsafe fn parse_uri_batch_16<'a>(bytes: &mut Bytes<'a>) {
+pub unsafe fn parse_uri_batch_16(bytes: &mut Bytes) {
     while bytes.as_ref().len() >= 16 {
         let advance = match_url_char_16_sse(bytes.as_ref());
         bytes.advance(advance);


### PR DESCRIPTION
For reference, this was the clippy output:

```
warning: redundant field names in struct initialization
  --> src/iter.rs:12:13
   |
12 |             slice: slice,
   |             ^^^^^^^^^^^^ help: replace it with: `slice`
   |
   = note: `#[warn(clippy::redundant_field_names)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: unnecessary `>= y + 1` or `x - 1 >=`
  --> src/iter.rs:29:23
   |
29 |         debug_assert!(self.pos + 1 <= self.slice.len(), "overflow");
   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: change it to: `self.pos < self.slice.len()`
   |
   = note: `#[warn(clippy::int_plus_one)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#int_plus_one

warning: redundant field names in struct initialization
   --> src/iter.rs:140:13
    |
140 |             bytes: bytes,
    |             ^^^^^^^^^^^^ help: replace it with: `bytes`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: digits of hex or binary literal not grouped by four
  --> src/simd/avx2.rs:62:13
   |
62 |     let r = 0xffffffff_00000000 | _mm256_movemask_epi8(v) as u64;
   |             ^^^^^^^^^^^^^^^^^^^ help: consider: `0xffff_ffff_0000_0000`
   |
   = note: `#[warn(clippy::unusual_byte_groupings)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unusual_byte_groupings

warning: digits of hex or binary literal not grouped by four
   --> src/simd/avx2.rs:112:15
    |
112 |     let res = 0xffffffff_00000000 | _mm256_movemask_epi8(rev) as u64;
    |               ^^^^^^^^^^^^^^^^^^^ help: consider: `0xffff_ffff_0000_0000`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unusual_byte_groupings

warning: redundant field names in struct initialization
   --> src/lib.rs:361:13
    |
361 |             headers: headers,
    |             ^^^^^^^^^^^^^^^^ help: replace it with: `headers`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: redundant field names in struct initialization
   --> src/lib.rs:464:13
    |
464 |             headers: headers,
    |             ^^^^^^^^^^^^^^^^ help: replace it with: `headers`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: use of `offset` with a `usize` casted to an `isize`
  --> src/iter.rs:59:42
   |
59 |         let tail = slice::from_raw_parts(ptr.offset(self.pos as isize), self.slice.len() - self.pos);
   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `ptr.add(self.pos)`
   |
   = note: `#[warn(clippy::ptr_offset_with_cast)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_offset_with_cast

warning: explicit lifetimes given in parameter types where they could be elided (or replaced with `'_` if needed by type declaration)
 --> src/simd/sse42.rs:3:1
  |
3 | pub unsafe fn parse_uri_batch_16<'a>(bytes: &mut Bytes<'a>) {
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(clippy::needless_lifetimes)]` on by default
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes

warning: explicit lifetimes given in parameter types where they could be elided (or replaced with `'_` if needed by type declaration)
  --> src/simd/avx2.rs:11:1
   |
11 | pub unsafe fn parse_uri_batch_32<'a>(bytes: &mut Bytes<'a>) -> Scan {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes

warning: replacing a value of type `T` with `T::default()` is better expressed using `std::mem::take`
   --> src/lib.rs:398:23
    |
398 |         let headers = mem::replace(&mut self.headers, &mut []);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `std::mem::take(&mut self.headers)`
    |
    = note: `#[warn(clippy::mem_replace_with_default)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#mem_replace_with_default

warning: replacing a value of type `T` with `T::default()` is better expressed using `std::mem::take`
   --> src/lib.rs:474:23
    |
474 |         let headers = mem::replace(&mut self.headers, &mut []);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `std::mem::take(&mut self.headers)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#mem_replace_with_default

warning: manual `RangeInclusive::contains` implementation
   --> src/lib.rs:653:47
    |
653 |         } else if !(b == 0x09 || b == b' ' || (b >= 0x21 && b <= 0x7E) || b >= 0x80) {
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `(0x21..=0x7E).contains(&b)`
    |
    = note: `#[warn(clippy::manual_range_contains)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_range_contains

warning: explicit lifetimes given in parameter types where they could be elided (or replaced with `'_` if needed by type declaration)
   --> src/lib.rs:751:1
    |
751 | unsafe fn assume_init_slice<'a, T>(s: &'a mut [MaybeUninit<T>]) -> &'a mut [T] {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes

warning: replacing a value of type `T` with `T::default()` is better expressed using `std::mem::take`
   --> src/lib.rs:783:27
    |
783 |             let headers = mem::replace(self.headers, &mut []);
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `std::mem::take(self.headers)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#mem_replace_with_default

warning: `httparse` (lib) generated 15 warnings
```