### PR TITLE
Clarify version struct documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,7 +344,7 @@ pub struct Request<'headers, 'buf: 'headers> {
     pub method: Option<&'buf str>,
     /// The request path, such as `/about-us`.
     pub path: Option<&'buf str>,
-    /// The request version, such as `HTTP/1.1`.
+    /// The request minor version, such as `1` for `HTTP/1.1`.
     pub version: Option<u8>,
     /// The request headers.
     pub headers: &'headers mut [Header<'buf>]
@@ -441,7 +441,7 @@ fn skip_empty_lines(bytes: &mut Bytes) -> Result<()> {
 /// See `Request` docs for explanation of optional values.
 #[derive(Debug, Eq, PartialEq)]
 pub struct Response<'headers, 'buf: 'headers> {
-    /// The response version, such as `HTTP/1.1`.
+    /// The response minor version, such as `1` for `HTTP/1.1`.
     pub version: Option<u8>,
     /// The response code, such as `200`.
     pub code: Option<u16>,


### PR DESCRIPTION
Previously the documentation for the version field on the Request and
Response structs stated the field contained values such as "HTTP/1.1".
This change clarifies the version field contains only the minor version
number.

Fixes #65 