### PR TITLE
Fix token and uri parsers to disallow empty results

### DIFF
--- a/tests/uri.rs
+++ b/tests/uri.rs
@@ -111,7 +111,7 @@ req! {
 req! {
     urltest_007,
     b"GET  foo.com HTTP/1.1\r\nHost: \r\n\r\n",
-    Err(Error::Version),
+    Err(Error::Token),
     |_r| {}
 }
 


### PR DESCRIPTION
This fixes cases where the parser would accept non-compliant request lines including empty methods and paths.

For the `token` grammar, [the spec][spec-token] is:

```
  token          = 1*tchar
```

`1*` is shorthand for one-or-more, so the empty string is not a valid `token`.

For the path component of the request line, [the spec][spec-path] we're concerned with the `absolute-path` grammar:

```
  absolute-path = 1*( "/" segment )
```

While `segment` might be empty, there must be at least a `"/"` for it to be syntactically valid.

I've added tests for these cases and their combination, and had to update the expected error of one of the existing URI tests which now fails sooner due to the empty path.

[spec-token]: https://httpwg.org/http-core/draft-ietf-httpbis-semantics-latest.html#tokens
[spec-path]: https://httpwg.org/http-core/draft-ietf-httpbis-semantics-latest.html#uri.references