### PR TITLE
run Miri on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
       - test
       - simd
       - msrv
+      - miri
     steps:
       - run: exit 0
 
@@ -127,3 +128,22 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
+
+  miri:
+    name: Test with Miri
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          components: miri
+          override: true
+
+      - name: Test
+        run: MIRIFLAGS="-Zmiri-tag-raw-pointers -Zmiri-check-number-validity" cargo miri test

--- a/build.rs
+++ b/build.rs
@@ -39,6 +39,10 @@ fn enable_simd(/*version: Version*/) {
         println!("cargo:warning=building for no_std disables httparse SIMD");
         return;
     }
+    if env::var_os("CARGO_CFG_MIRI").is_some() {
+        println!("cargo:warning=building for Miri disables httparse SIMD");
+        return;
+    }
 
     let env_disable = "CARGO_CFG_HTTPARSE_DISABLE_SIMD";
     if var_is(env_disable, "1") {


### PR DESCRIPTION
This only works if we use the fallback implementation with Miri.

(FWIW, using `core::simd` would work, but `core::arch` simply has too many intrinsics to support them all in Miri.)