### PR TITLE
Improve request method parsing

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -21,7 +21,12 @@ impl<'a> Bytes<'a> {
 
     #[inline]
     pub fn peek(&self) -> Option<u8> {
-        self.slice.get(self.pos).cloned()
+        self.peek_ahead(0)
+    }
+
+    #[inline]
+    pub fn peek_ahead(&self, n: usize) -> Option<u8> {
+        self.slice.get(self.pos + n).cloned()
     }
 
     #[inline]

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -25,6 +25,15 @@ impl<'a> Bytes<'a> {
     }
 
     #[inline]
+    pub fn peek_4(&self) -> Option<&[u8]> {
+        if self.slice.len() >= self.pos + 4 {
+            Some(&self.slice[self.pos..=self.pos + 3])
+        } else {
+            None
+        }
+    }
+
+    #[inline]
     pub unsafe fn bump(&mut self) {
         debug_assert!(self.pos < self.slice.len(), "overflow");
         self.pos += 1;
@@ -60,6 +69,16 @@ impl<'a> Bytes<'a> {
         self.pos = 0;
         self.slice = tail;
         head
+    }
+
+    #[inline]
+    pub unsafe fn advance_and_commit(&mut self, n: usize) {
+        debug_assert!(self.pos + n <= self.slice.len(), "overflow");
+        self.pos += n;
+        let ptr = self.slice.as_ptr();
+        let tail = slice::from_raw_parts(ptr.add(n), self.slice.len() - n);
+        self.pos = 0;
+        self.slice = tail;
     }
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -475,10 +475,19 @@ impl<'h, 'b> Request<'h, 'b> {
         config: &ParserConfig,
         mut headers: &'h mut [MaybeUninit<Header<'b>>],
     ) -> Result<usize> {
-    let orig_len = buf.len();
+        let orig_len = buf.len();
         let mut bytes = Bytes::new(buf);
         complete!(skip_empty_lines(&mut bytes));
-        self.method = Some(complete!(parse_token(&mut bytes)));
+        let method = match bytes.peek_4() {
+            Some(b"GET ") => {
+                unsafe {
+                    bytes.advance_and_commit(4);
+                }
+                "GET"
+            }
+            _ => complete!(parse_token(&mut bytes)),
+        };
+        self.method = Some(method);
         if config.allow_multiple_spaces_in_request_line_delimiters {
             complete!(skip_spaces(&mut bytes));
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -485,6 +485,12 @@ impl<'h, 'b> Request<'h, 'b> {
                 }
                 "GET"
             }
+            Some(b"POST") if bytes.peek_ahead(4) == Some(b' ') => {
+                unsafe {
+                    bytes.advance_and_commit(5);
+                }
+                "POST"
+            }
             _ => complete!(parse_token(&mut bytes)),
         };
         self.method = Some(method);


### PR DESCRIPTION
Special-case parsing of the GET request method as that is by far the
most common. Speeds up the req_short benchmark by a fair margin:

       req_short/req_short     time:   [32.601 ns 32.737 ns 32.914 ns]
                            thrpt:  [1.9241 GiB/s 1.9345 GiB/s 1.9425 GiB/s]
                     change:
                            time:   [-4.1113% -3.5415% -3.0150%] (p = 0.00 < 0.05)
                            thrpt:  [+3.1087% +3.6715% +4.2876%]
                            Performance has improved.

Co-authored-by: Luca Casonato <hello@lcas.dev>
