### PR TITLE
Edition 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/httparse"
 readme = "README.md"
 keywords = ["http", "parser", "no_std"]
 categories = ["network-programming", "no-std", "parser-implementations", "web-programming"]
-
+edition = "2018"
 build = "build.rs"
 
 [features]

--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -1,16 +1,14 @@
-extern crate criterion;
-extern crate httparse;
 
 use std::time::Duration;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
 
-const REQ_SHORT: &'static [u8] = b"\
+const REQ_SHORT: &[u8] = b"\
 GET / HTTP/1.0\r\n\
 Host: example.com\r\n\
 Cookie: session=60; user_id=1\r\n\r\n";
 
-const REQ: &'static [u8] = b"\
+const REQ: &[u8] = b"\
 GET /wp-content/uploads/2010/03/hello-kitty-darth-vader-pink.jpg HTTP/1.1\r\n\
 Host: www.kittyhell.com\r\n\
 User-Agent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; ja-JP-mac; rv:1.9.2.3) Gecko/20100401 Firefox/3.6.3 Pathtraq/0.9\r\n\
@@ -44,13 +42,13 @@ fn req_short(c: &mut Criterion) {
         }));
 }
 
-const RESP_SHORT: &'static [u8] = b"\
+const RESP_SHORT: &[u8] = b"\
 HTTP/1.0 200 OK\r\n\
 Date: Wed, 21 Oct 2015 07:28:00 GMT\r\n\
 Set-Cookie: session=60; user_id=1\r\n\r\n";
 
 // These particular headers don't all make semantic sense for a response, but they're syntactically valid.
-const RESP: &'static [u8] = b"\
+const RESP: &[u8] = b"\
 HTTP/1.1 200 OK\r\n\
 Date: Wed, 21 Oct 2015 07:28:00 GMT\r\n\
 Host: www.kittyhell.com\r\n\

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -28,7 +28,7 @@ impl<'a> Bytes<'a> {
 
     #[inline]
     pub fn peek_ahead(&self, n: usize) -> Option<u8> {
-        self.slice.get(self.pos + n).cloned()
+        self.slice.get(self.pos + n).copied()
     }
 
     #[inline]

--- a/src/simd/avx2.rs
+++ b/src/simd/avx2.rs
@@ -129,7 +129,7 @@ fn avx2_code_matches_uri_chars_table() {
     unsafe {
         assert!(byte_is_allowed(b'_', parse_uri_batch_32));
 
-        for (b, allowed) in ::URI_MAP.iter().cloned().enumerate() {
+        for (b, allowed) in crate::URI_MAP.iter().cloned().enumerate() {
             assert_eq!(
                 byte_is_allowed(b as u8, parse_uri_batch_32), allowed,
                 "byte_is_allowed({:?}) should be {:?}", b, allowed,
@@ -148,7 +148,7 @@ fn avx2_code_matches_header_value_chars_table() {
     unsafe {
         assert!(byte_is_allowed(b'_', match_header_value_batch_32));
 
-        for (b, allowed) in ::HEADER_VALUE_MAP.iter().cloned().enumerate() {
+        for (b, allowed) in crate::HEADER_VALUE_MAP.iter().cloned().enumerate() {
             assert_eq!(
                 byte_is_allowed(b as u8, match_header_value_batch_32), allowed,
                 "byte_is_allowed({:?}) should be {:?}", b, allowed,

--- a/src/simd/avx2.rs
+++ b/src/simd/avx2.rs
@@ -1,4 +1,4 @@
-use ::iter::Bytes;
+use crate::iter::Bytes;
 
 pub enum Scan {
     /// Returned when an implementation finds a noteworthy token.

--- a/src/simd/fallback.rs
+++ b/src/simd/fallback.rs
@@ -1,8 +1,8 @@
-use ::iter::Bytes;
+use crate::iter::Bytes;
 
 // Fallbacks that do nothing...
 
 #[inline(always)]
-pub fn match_uri_vectored(_: &mut Bytes) {}
+pub fn match_uri_vectored(_: &mut Bytes<'_>) {}
 #[inline(always)]
-pub fn match_header_value_vectored(_: &mut Bytes) {}
+pub fn match_header_value_vectored(_: &mut Bytes<'_>) {}

--- a/src/simd/mod.rs
+++ b/src/simd/mod.rs
@@ -69,7 +69,7 @@ pub const AVX_2: usize = 2;
 ))]
 pub const AVX_2_AND_SSE_42: usize = 3;
 #[cfg(httparse_simd)]
-const NONE: usize = ::core::usize::MAX;
+const NONE: usize = usize::MAX;
 #[cfg(all(
     httparse_simd,
     not(any(
@@ -116,7 +116,7 @@ mod runtime {
         feat
     }
 
-    pub fn match_uri_vectored(bytes: &mut ::Bytes) {
+    pub fn match_uri_vectored(bytes: &mut crate::iter::Bytes) {
         unsafe {
             match detect() {
                 super::SSE_42 => super::sse42::parse_uri_batch_16(bytes),
@@ -134,7 +134,7 @@ mod runtime {
         // else do nothing
     }
 
-    pub fn match_header_value_vectored(bytes: &mut ::Bytes) {
+    pub fn match_header_value_vectored(bytes: &mut crate::iter::Bytes) {
         unsafe {
             match detect() {
                 super::SSE_42 => super::sse42::match_header_value_batch_16(bytes),
@@ -176,7 +176,7 @@ pub use self::runtime::*;
     ),
 ))]
 mod sse42_compile_time {
-    pub fn match_uri_vectored(bytes: &mut ::Bytes) {
+    pub fn match_uri_vectored(bytes: &mut crate::iter::Bytes) {
         if detect() == super::SSE_42 {
             unsafe {
                 super::sse42::parse_uri_batch_16(bytes);
@@ -186,7 +186,7 @@ mod sse42_compile_time {
         // else do nothing
     }
 
-    pub fn match_header_value_vectored(bytes: &mut ::Bytes) {
+    pub fn match_header_value_vectored(bytes: &mut crate::iter::Bytes) {
         if detect() == super::SSE_42 {
             unsafe {
                 super::sse42::match_header_value_batch_16(bytes);
@@ -225,7 +225,7 @@ pub use self::sse42_compile_time::*;
     ),
 ))]
 mod avx2_compile_time {
-    pub fn match_uri_vectored(bytes: &mut ::Bytes) {
+    pub fn match_uri_vectored(bytes: &mut crate::iter::Bytes) {
         // do both, since avx2 only works when bytes.len() >= 32
         if detect() == super::AVX_2_AND_SSE_42 {
             unsafe {
@@ -242,7 +242,7 @@ mod avx2_compile_time {
         // else do nothing
     }
 
-    pub fn match_header_value_vectored(bytes: &mut ::Bytes) {
+    pub fn match_header_value_vectored(bytes: &mut crate::iter::Bytes) {
         // do both, since avx2 only works when bytes.len() >= 32
         if detect() == super::AVX_2_AND_SSE_42 {
             let scanned = unsafe {

--- a/src/simd/mod.rs
+++ b/src/simd/mod.rs
@@ -68,8 +68,15 @@ pub const AVX_2: usize = 2;
     ),
 ))]
 pub const AVX_2_AND_SSE_42: usize = 3;
-#[cfg(httparse_simd)]
-const NONE: usize = usize::MAX;
+
+#[cfg(all(
+    httparse_simd,
+    any(
+        target_arch = "x86",
+        target_arch = "x86_64",
+    ),
+))]
+const NONE: usize = std::usize::MAX;
 #[cfg(all(
     httparse_simd,
     not(any(

--- a/src/simd/sse42.rs
+++ b/src/simd/sse42.rs
@@ -1,4 +1,4 @@
-use ::iter::Bytes;
+use crate::iter::Bytes;
 
 pub unsafe fn parse_uri_batch_16(bytes: &mut Bytes) {
     while bytes.as_ref().len() >= 16 {

--- a/src/simd/sse42.rs
+++ b/src/simd/sse42.rs
@@ -109,7 +109,7 @@ fn sse_code_matches_uri_chars_table() {
     unsafe {
         assert!(byte_is_allowed(b'_', parse_uri_batch_16));
 
-        for (b, allowed) in ::URI_MAP.iter().cloned().enumerate() {
+        for (b, allowed) in crate::URI_MAP.iter().cloned().enumerate() {
             assert_eq!(
                 byte_is_allowed(b as u8, parse_uri_batch_16), allowed,
                 "byte_is_allowed({:?}) should be {:?}", b, allowed,
@@ -128,7 +128,7 @@ fn sse_code_matches_header_value_chars_table() {
     unsafe {
         assert!(byte_is_allowed(b'_', match_header_value_batch_16));
 
-        for (b, allowed) in ::HEADER_VALUE_MAP.iter().cloned().enumerate() {
+        for (b, allowed) in crate::HEADER_VALUE_MAP.iter().cloned().enumerate() {
             assert_eq!(
                 byte_is_allowed(b as u8, match_header_value_batch_16), allowed,
                 "byte_is_allowed({:?}) should be {:?}", b, allowed,

--- a/tests/uri.rs
+++ b/tests/uri.rs
@@ -1,4 +1,3 @@
-extern crate httparse;
 
 use httparse::{Error, Request, Status, EMPTY_HEADER};
 
@@ -17,7 +16,7 @@ macro_rules! req {
         assert_eq!(status, $len);
         closure(req);
 
-        fn closure($arg: Request) {
+        fn closure($arg: Request<'_, '_>) {
             $body
         }
     }


### PR DESCRIPTION
Due to `MaybeUninit`, the crate already wasn't compatible with any pre-2018 Rust version.