### PR TITLE
Improve granularity of benchmarks

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -2,11 +2,13 @@ use core::slice;
 use core::convert::TryInto;
 use core::convert::TryFrom;
 
+#[allow(missing_docs)]
 pub struct Bytes<'a> {
     slice: &'a [u8],
     pos: usize
 }
 
+#[allow(missing_docs)]
 impl<'a> Bytes<'a> {
     #[inline]
     pub fn new(slice: &'a [u8]) -> Bytes<'a> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,8 +30,9 @@ mod iter;
 #[macro_use] mod macros;
 mod simd;
 
-// Expose some internal functions so we can bench them individually
 #[doc(hidden)]
+// Expose some internal functions so we can bench them individually
+// WARNING: Exported for internal benchmarks, not fit for public consumption
 pub mod _benchable {
     pub use super::parse_uri;
     pub use super::parse_version;
@@ -738,6 +739,7 @@ pub const EMPTY_HEADER: Header<'static> = Header { name: "", value: b"" };
 #[inline]
 #[doc(hidden)]
 #[allow(missing_docs)]
+// WARNING: Exported for internal benchmarks, not fit for public consumption
 pub fn parse_version(bytes: &mut Bytes) -> Result<u8> {
     if let Some(eight) = bytes.peek_n::<[u8; 8]>(8) {
         unsafe { bytes.advance(8); }
@@ -765,6 +767,7 @@ pub fn parse_version(bytes: &mut Bytes) -> Result<u8> {
 #[inline]
 #[doc(hidden)]
 #[allow(missing_docs)]
+// WARNING: Exported for internal benchmarks, not fit for public consumption
 pub fn parse_method<'a>(bytes: &mut Bytes<'a>) -> Result<&'a str> {
     const GET: [u8; 4] = *b"GET ";
     const POST: [u8; 4] = *b"POST";
@@ -858,6 +861,7 @@ fn parse_token<'a>(bytes: &mut Bytes<'a>) -> Result<&'a str> {
 #[inline]
 #[doc(hidden)]
 #[allow(missing_docs)]
+// WARNING: Exported for internal benchmarks, not fit for public consumption
 pub fn parse_uri<'a>(bytes: &mut Bytes<'a>) -> Result<&'a str> {
     let b = next!(bytes);
     if !is_uri_token(b) {


### PR DESCRIPTION
To provide better baselines for perf work, etc...

It unfortunately requires exposing a few functions as public, though they are hidden from the docs and re-exported under a `_benchable` mod

I wanted to land this first to have a solid baseline to frame the other performance improvements I'll submit shortly

## Current baseline

```
test req/req ... bench:                 223 ns/iter (+/- 8)
test req_short/req_short ... bench:     29 ns/iter (+/- 0)
test resp/resp ... bench:               212 ns/iter (+/- 4)
test resp_short/resp_short ... bench:   35 ns/iter (+/- 1)
test uri/uri_1b ... bench:              0 ns/iter (+/- 0)
test uri/uri_2b ... bench:              1 ns/iter (+/- 0)
test uri/uri_4b ... bench:              2 ns/iter (+/- 0)
test uri/uri_8b ... bench:              3 ns/iter (+/- 0)
test uri/uri_16b ... bench:             7 ns/iter (+/- 0)
test uri/uri_32b ... bench:             15 ns/iter (+/- 0)
test uri/uri_64b ... bench:             30 ns/iter (+/- 0)
test uri/uri_128b ... bench:            67 ns/iter (+/- 0)
test uri/uri_256b ... bench:            129 ns/iter (+/- 2)
test uri/uri_512b ... bench:            250 ns/iter (+/- 3)
test uri/uri_1024b ... bench:           494 ns/iter (+/- 5)
test uri/uri_2048b ... bench:           990 ns/iter (+/- 19)
test uri/uri_4096b ... bench:           2069 ns/iter (+/- 525)
test header/name_1b ... bench:          8 ns/iter (+/- 0)
test header/name_2b ... bench:          9 ns/iter (+/- 0)
test header/name_4b ... bench:          10 ns/iter (+/- 0)
test header/name_8b ... bench:          11 ns/iter (+/- 0)
test header/name_16b ... bench:         15 ns/iter (+/- 0)
test header/name_32b ... bench:         23 ns/iter (+/- 0)
test header/name_64b ... bench:         38 ns/iter (+/- 0)
test header/name_128b ... bench:        79 ns/iter (+/- 3)
test header/name_256b ... bench:        137 ns/iter (+/- 2)
test header/name_512b ... bench:        265 ns/iter (+/- 9)
test header/name_1024b ... bench:       506 ns/iter (+/- 10)
test header/name_2048b ... bench:       994 ns/iter (+/- 19)
test header/name_4096b ... bench:       1974 ns/iter (+/- 28)
test header/value_1b ... bench:         8 ns/iter (+/- 0)
test header/value_2b ... bench:         9 ns/iter (+/- 0)
test header/value_4b ... bench:         10 ns/iter (+/- 0)
test header/value_8b ... bench:         9 ns/iter (+/- 0)
test header/value_16b ... bench:        10 ns/iter (+/- 0)
test header/value_32b ... bench:        14 ns/iter (+/- 0)
test header/value_64b ... bench:        20 ns/iter (+/- 0)
test header/value_128b ... bench:       33 ns/iter (+/- 0)
test header/value_256b ... bench:       60 ns/iter (+/- 1)
test header/value_512b ... bench:       127 ns/iter (+/- 2)
test header/value_1024b ... bench:      233 ns/iter (+/- 5)
test header/value_2048b ... bench:      456 ns/iter (+/- 11)
test header/value_4096b ... bench:      893 ns/iter (+/- 23)
test header/count_1 ... bench:          8 ns/iter (+/- 0)
test header/count_2 ... bench:          13 ns/iter (+/- 0)
test header/count_4 ... bench:          25 ns/iter (+/- 0)
test header/count_8 ... bench:          45 ns/iter (+/- 0)
test header/count_16 ... bench:         92 ns/iter (+/- 0)
test header/count_32 ... bench:         175 ns/iter (+/- 2)
test header/count_64 ... bench:         342 ns/iter (+/- 8)
test header/count_128 ... bench:        673 ns/iter (+/- 19)
test version/http10 ... bench:          0 ns/iter (+/- 0)
test version/http11 ... bench:          0 ns/iter (+/- 0)
test version/partial ... bench:         1 ns/iter (+/- 0)
test method/get ... bench:              0 ns/iter (+/- 0)
test method/head ... bench:             2 ns/iter (+/- 0)
test method/post ... bench:             1 ns/iter (+/- 0)
test method/put ... bench:              2 ns/iter (+/- 0)
test method/delete ... bench:           3 ns/iter (+/- 0)
test method/connect ... bench:          3 ns/iter (+/- 0)
test method/options ... bench:          3 ns/iter (+/- 0)
test method/trace ... bench:            2 ns/iter (+/- 0)
test method/patch ... bench:            3 ns/iter (+/- 0)
test method/custom ... bench:           3 ns/iter (+/- 0)
```