### PR TITLE
cleanup: SIMD runtime detection

### DIFF
--- a/src/simd/mod.rs
+++ b/src/simd/mod.rs
@@ -40,45 +40,6 @@ mod avx2;
 
 #[cfg(all(
     httparse_simd,
-    any(
-        target_arch = "x86",
-        target_arch = "x86_64",
-    ),
-))]
-pub const SSE_42: usize = 1;
-#[cfg(all(
-    httparse_simd,
-    any(not(httparse_simd_target_feature_sse42), httparse_simd_target_feature_avx2),
-    any(
-        target_arch = "x86",
-        target_arch = "x86_64",
-    ),
-))]
-pub const AVX_2: usize = 2;
-#[cfg(all(
-    httparse_simd,
-    any(
-        not(httparse_simd_target_feature_sse42),
-        httparse_simd_target_feature_avx2,
-        test,
-    ),
-    any(
-        target_arch = "x86",
-        target_arch = "x86_64",
-    ),
-))]
-pub const AVX_2_AND_SSE_42: usize = 3;
-
-#[cfg(all(
-    httparse_simd,
-    any(
-        target_arch = "x86",
-        target_arch = "x86_64",
-    ),
-))]
-const NONE: usize = std::usize::MAX;
-#[cfg(all(
-    httparse_simd,
     not(any(
         httparse_simd_target_feature_sse42,
         httparse_simd_target_feature_avx2,
@@ -88,77 +49,7 @@ const NONE: usize = std::usize::MAX;
         target_arch = "x86_64",
     ),
 ))]
-mod runtime {
-    //! Runtime detection of simd features. Used when the build script
-    //! doesn't notice any target features at build time.
-    //!
-    //! While `is_x86_feature_detected!` has it's own caching built-in,
-    //! at least in 1.27.0, the functions don't inline, leaving using it
-    //! actually *slower* than just using the scalar fallback.
-
-    use core::sync::atomic::{AtomicUsize, Ordering};
-
-    static FEATURE: AtomicUsize = AtomicUsize::new(0);
-
-    const INIT: usize = 0;
-
-    pub fn detect() -> usize {
-        let feat = FEATURE.load(Ordering::Relaxed);
-        if feat == INIT {
-            if cfg!(target_arch = "x86_64") && is_x86_feature_detected!("avx2") {
-                if is_x86_feature_detected!("sse4.2") {
-                    FEATURE.store(super::AVX_2_AND_SSE_42, Ordering::Relaxed);
-                    return super::AVX_2_AND_SSE_42;
-                } else {
-                    FEATURE.store(super::AVX_2, Ordering::Relaxed);
-                    return super::AVX_2;
-                }
-            } else if is_x86_feature_detected!("sse4.2") {
-                FEATURE.store(super::SSE_42, Ordering::Relaxed);
-                return super::SSE_42;
-            } else {
-                FEATURE.store(super::NONE, Ordering::Relaxed);
-            }
-        }
-        feat
-    }
-
-    pub fn match_uri_vectored(bytes: &mut crate::iter::Bytes) {
-        unsafe {
-            match detect() {
-                super::SSE_42 => super::sse42::parse_uri_batch_16(bytes),
-                super::AVX_2 => { super::avx2::parse_uri_batch_32(bytes); },
-                super::AVX_2_AND_SSE_42 => {
-                    if let super::avx2::Scan::Found = super::avx2::parse_uri_batch_32(bytes) {
-                        return;
-                    }
-                    super::sse42::parse_uri_batch_16(bytes)
-                },
-                _ => ()
-            }
-        }
-
-        // else do nothing
-    }
-
-    pub fn match_header_value_vectored(bytes: &mut crate::iter::Bytes) {
-        unsafe {
-            match detect() {
-                super::SSE_42 => super::sse42::match_header_value_batch_16(bytes),
-                super::AVX_2 => { super::avx2::match_header_value_batch_32(bytes); },
-                super::AVX_2_AND_SSE_42 => {
-                    if let super::avx2::Scan::Found = super::avx2::match_header_value_batch_32(bytes) {
-                        return;
-                    }
-                    super::sse42::match_header_value_batch_16(bytes)
-                },
-                _ => ()
-            }
-        }
-
-        // else do nothing
-    }
-}
+mod runtime;
 
 #[cfg(all(
     httparse_simd,
@@ -183,32 +74,16 @@ pub use self::runtime::*;
     ),
 ))]
 mod sse42_compile_time {
-    pub fn match_uri_vectored(bytes: &mut crate::iter::Bytes) {
-        if detect() == super::SSE_42 {
-            unsafe {
-                super::sse42::parse_uri_batch_16(bytes);
-            }
-        }
-
-        // else do nothing
+    #[inline(always)]
+    pub fn match_uri_vectored(b: &mut crate::iter::Bytes<'_>) {
+        // SAFETY: calls are guarded by a compile time feature check
+        unsafe { crate::simd::sse42::match_uri_vectored(b) }
     }
-
-    pub fn match_header_value_vectored(bytes: &mut crate::iter::Bytes) {
-        if detect() == super::SSE_42 {
-            unsafe {
-                super::sse42::match_header_value_batch_16(bytes);
-            }
-        }
-
-        // else do nothing
-    }
-
-    pub fn detect() -> usize {
-        if is_x86_feature_detected!("sse4.2") {
-            super::SSE_42
-        } else {
-            super::NONE
-        }
+    
+    #[inline(always)]
+    pub fn match_header_value_vectored(b: &mut crate::iter::Bytes<'_>) {
+        // SAFETY: calls are guarded by a compile time feature check
+        unsafe { crate::simd::sse42::match_header_value_vectored(b) }
     }
 }
 
@@ -232,51 +107,16 @@ pub use self::sse42_compile_time::*;
     ),
 ))]
 mod avx2_compile_time {
-    pub fn match_uri_vectored(bytes: &mut crate::iter::Bytes) {
-        // do both, since avx2 only works when bytes.len() >= 32
-        if detect() == super::AVX_2_AND_SSE_42 {
-            unsafe {
-                super::avx2::parse_uri_batch_32(bytes);
-            }
-
-        } 
-        if detect() == super::SSE_42 {
-            unsafe {
-                super::sse42::parse_uri_batch_16(bytes);
-            }
-        }
-
-        // else do nothing
+    #[inline(always)]
+    pub fn match_uri_vectored(b: &mut crate::iter::Bytes<'_>) {
+        // SAFETY: calls are guarded by a compile time feature check
+        unsafe { crate::simd::avx2::match_uri_vectored(b) }
     }
-
-    pub fn match_header_value_vectored(bytes: &mut crate::iter::Bytes) {
-        // do both, since avx2 only works when bytes.len() >= 32
-        if detect() == super::AVX_2_AND_SSE_42 {
-            let scanned = unsafe {
-                super::avx2::match_header_value_batch_32(bytes)
-            };
-
-            if let super::avx2::Scan::Found = scanned {
-                return;
-            }
-        }
-        if detect() == super::SSE_42 {
-            unsafe {
-                super::sse42::match_header_value_batch_16(bytes);
-            }
-        }
-
-        // else do nothing
-    }
-
-    pub fn detect() -> usize {
-        if cfg!(target_arch = "x86_64") && is_x86_feature_detected!("avx2") {
-            super::AVX_2_AND_SSE_42
-        } else if is_x86_feature_detected!("sse4.2") {
-            super::SSE_42
-        } else {
-            super::NONE
-        }
+    
+    #[inline(always)]
+    pub fn match_header_value_vectored(b: &mut crate::iter::Bytes<'_>) {
+        // SAFETY: calls are guarded by a compile time feature check
+        unsafe { crate::simd::avx2::match_header_value_vectored(b) }
     }
 }
 

--- a/src/simd/runtime.rs
+++ b/src/simd/runtime.rs
@@ -1,0 +1,53 @@
+use std::sync::atomic::{AtomicU8, Ordering};
+use crate::iter::Bytes;
+use super::avx2;
+use super::sse42;
+
+const AVX2: u8 = 1;
+const SSE42: u8 = 2;
+const NOP: u8 = 3;
+
+fn detect_runtime_feature() -> u8 {
+    if is_x86_feature_detected!("avx2") {
+        AVX2
+    } else if is_x86_feature_detected!("sse4.2") {
+        SSE42
+    } else {
+        NOP
+    }
+}
+
+static RUNTIME_FEATURE: AtomicU8 = AtomicU8::new(0);
+
+#[inline]
+fn get_runtime_feature() -> u8 {
+    let mut feature = RUNTIME_FEATURE.load(Ordering::Relaxed);
+    if feature == 0 {
+        feature = detect_runtime_feature();
+        RUNTIME_FEATURE.store(feature, Ordering::Relaxed);
+    }
+
+    feature
+}
+
+pub fn match_uri_vectored(bytes: &mut Bytes) {
+    // SAFETY: calls are guarded by a feature check
+    unsafe {
+        match get_runtime_feature() {
+            AVX2 => avx2::match_uri_vectored(bytes),
+            SSE42 => sse42::match_uri_vectored(bytes),
+            _ => {},
+        }
+    }
+}
+
+pub fn match_header_value_vectored(bytes: &mut Bytes) {
+    // SAFETY: calls are guarded by a feature check
+    unsafe {
+        match get_runtime_feature() {
+            AVX2 => avx2::match_header_value_vectored(bytes),
+            SSE42 => sse42::match_header_value_vectored(bytes),
+            _ => {},
+        }
+    }
+}


### PR DESCRIPTION
Also cleanup, builds off #131

We can see the overhead improvements in uri parsing for smaller values (where overhead is relatively significant) and we can see it compound in header/count accumulating the overhead of jumping in & out of SIMD.

## header/count

|         | 1   | 2   | 4   | 8   | 16  | 32  | 64  | 128 |
|---------|-----|-----|-----|-----|-----|-----|-----|-----|
| Before | 22  | 39  | 77  | 144 | 283 | 578 | 1092| 2159|
| After  | 21  | 37  | 71  | 135 | 271 | 568 | 1025| 2034|

## uri

|         | 1b  | 2b  | 4b  | 8b  | 16b | 32b | 64b | 128b | 256b | 512b | 1024b | 2048b | 4096b |
|---------|-----|-----|-----|-----|-----|-----|-----|------|------|------|-------|-------|-------|
| Before | 7   | 8   | 9   | 11  | 8   | 6   | 7   | 11   | 19   | 34   | 67    | 127   | 270   |
| After  | 5   | 5   | 7   | 9   | 6   | 5   | 6   | 9    | 20   | 31   | 60    | 119   | 255   |
