### PR TITLE
simd: drop 2 unnecessary instructions

### DIFF
--- a/src/simd/avx2.rs
+++ b/src/simd/avx2.rs
@@ -108,10 +108,9 @@ unsafe fn match_header_value_char_32_avx(buf: &[u8]) -> usize {
     let tab = _mm256_cmpeq_epi8(dat, TAB);
     let del = _mm256_cmpeq_epi8(dat, DEL);
     let bit = _mm256_andnot_si256(del, _mm256_or_si256(low, tab));
-    let rev = _mm256_cmpeq_epi8(bit, _mm256_setzero_si256());
-    let res = _mm256_movemask_epi8(rev) as u32;
-
-    res.trailing_zeros() as usize
+    let res = _mm256_movemask_epi8(bit) as u32;
+    // TODO: use .trailing_ones() once MSRV >= 1.46
+    (!res).trailing_zeros() as usize
 }
 
 #[test]

--- a/src/simd/sse42.rs
+++ b/src/simd/sse42.rs
@@ -97,10 +97,10 @@ unsafe fn match_header_value_char_16_sse(buf: &[u8]) -> usize {
     let tab = _mm_cmpeq_epi8(dat, TAB);
     let del = _mm_cmpeq_epi8(dat, DEL);
     let bit = _mm_andnot_si128(del, _mm_or_si128(low, tab));
-    let rev = _mm_cmpeq_epi8(bit, _mm_setzero_si128());
-    let res = _mm_movemask_epi8(rev) as u16;
+    let res = _mm_movemask_epi8(bit) as u16;
 
-    res.trailing_zeros() as usize
+    // TODO: use .trailing_ones() once MSRV >= 1.46
+    (!res).trailing_zeros() as usize
 }
 
 #[test]


### PR DESCRIPTION
## Benches

```
before:
test header/value_256b ... bench:          34 ns/iter (+/- 13)
test header/value_512b ... bench:          50 ns/iter (+/- 5)
test header/value_1024b ... bench:          86 ns/iter (+/- 7)
test header/value_2048b ... bench:         172 ns/iter (+/- 20)
test header/value_4096b ... bench:         298 ns/iter (+/- 62)

after:
test header/value_256b ... bench:          33 ns/iter (+/- 10)
test header/value_512b ... bench:          48 ns/iter (+/- 20)
test header/value_1024b ... bench:          77 ns/iter (+/- 8)
test header/value_2048b ... bench:         149 ns/iter (+/- 8)
test header/value_4096b ... bench:         252 ns/iter (+/- 50)
```