### PR TITLE
Add more `cargo-fuzz` targets

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -36,3 +36,9 @@ name = "parse_headers"
 path = "fuzz_targets/parse_headers.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "parse_response"
+path = "fuzz_targets/parse_response.rs"
+test = false
+doc = false

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -42,3 +42,15 @@ name = "parse_response"
 path = "fuzz_targets/parse_response.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "parse_response_multspaces"
+path = "fuzz_targets/parse_response_multspaces.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "parse_request_multspaces"
+path = "fuzz_targets/parse_request_multspaces.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/parse_request_multspaces.rs
+++ b/fuzz/fuzz_targets/parse_request_multspaces.rs
@@ -1,0 +1,11 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let mut headers = [httparse::EMPTY_HEADER; 16];
+    let mut resp = httparse::Request::new(&mut headers);
+    let _ = httparse::ParserConfig::default()
+        .allow_multiple_spaces_in_request_line_delimiters(true)
+        .parse_request(&mut resp, data);
+});

--- a/fuzz/fuzz_targets/parse_response.rs
+++ b/fuzz/fuzz_targets/parse_response.rs
@@ -1,0 +1,8 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let mut headers = [httparse::EMPTY_HEADER; 16];
+    let mut resp = httparse::Response::new(&mut headers);
+    let _ = resp.parse(data);
+});

--- a/fuzz/fuzz_targets/parse_response_multspaces.rs
+++ b/fuzz/fuzz_targets/parse_response_multspaces.rs
@@ -1,0 +1,11 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let mut headers = [httparse::EMPTY_HEADER; 16];
+    let mut resp = httparse::Response::new(&mut headers);
+    let _ = httparse::ParserConfig::default()
+        .allow_multiple_spaces_in_response_status_delimiters(true)
+        .parse_response(&mut resp, data);
+});


### PR DESCRIPTION
Add new fuzzing targets:
* Parsing responses.
* Parsing responses with multiple spaces enabled.
* Parsing requests with multiple spaces enabled.