### PR TITLE
Apply black_box to known bench inputs

### DIFF
--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -1,7 +1,6 @@
-
 use std::time::Duration;
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput, BatchSize};
 
 const REQ_SHORT: &[u8] = b"\
 GET / HTTP/1.0\r\n\
@@ -21,25 +20,37 @@ Connection: keep-alive\r\n\
 Cookie: wp_ozh_wsa_visits=2; wp_ozh_wsa_visit_lasttime=xxxxxxxxxx; __utma=xxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.x; __utmz=xxxxxxxxx.xxxxxxxxxx.x.x.utmccn=(referral)|utmcsr=reader.livedoor.com|utmcct=/reader/|utmcmd=referral|padding=under256\r\n\r\n";
 
 fn req(c: &mut Criterion) {
-    let mut headers = [httparse::Header{ name: "", value: &[] }; 16];
-    let mut req = httparse::Request::new(&mut headers);
-
     c.benchmark_group("req")
         .throughput(Throughput::Bytes(REQ.len() as u64))
-        .bench_function("req", |b| b.iter(|| {
-            assert_eq!(black_box(req.parse(REQ).unwrap()), httparse::Status::Complete(REQ.len()));
-        }));
+        .bench_function("req", |b| b.iter_batched_ref(|| {
+            [httparse::Header {
+                name: "",
+                value: &[],
+            }; 16]
+        },|headers| {
+            let mut req = httparse::Request::new(headers);
+            assert_eq!(
+                black_box(req.parse(REQ).unwrap()),
+                httparse::Status::Complete(REQ.len())
+            );
+        }, BatchSize::SmallInput));
 }
 
 fn req_short(c: &mut Criterion) {
-    let mut headers = [httparse::Header{ name: "", value: &[] }; 16];
-    let mut req = httparse::Request::new(&mut headers);
-
     c.benchmark_group("req_short")
         .throughput(Throughput::Bytes(REQ_SHORT.len() as u64))
-        .bench_function("req_short", |b| b.iter(|| {
-            assert_eq!(black_box(req.parse(REQ_SHORT).unwrap()), httparse::Status::Complete(REQ_SHORT.len()));
-        }));
+        .bench_function("req_short", |b| b.iter_batched_ref(|| {
+            [httparse::Header {
+                name: "",
+                value: &[],
+            }; 16]
+        },|headers| {
+            let mut req = httparse::Request::new(headers);
+            assert_eq!(
+                req.parse(black_box(REQ_SHORT)).unwrap(),
+                httparse::Status::Complete(REQ_SHORT.len())
+            );
+        }, BatchSize::SmallInput));
 }
 
 const RESP_SHORT: &[u8] = b"\
@@ -62,25 +73,38 @@ Connection: keep-alive\r\n\
 Cookie: wp_ozh_wsa_visits=2; wp_ozh_wsa_visit_lasttime=xxxxxxxxxx; __utma=xxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.xxxxxxxxxx.x; __utmz=xxxxxxxxx.xxxxxxxxxx.x.x.utmccn=(referral)|utmcsr=reader.livedoor.com|utmcct=/reader/|utmcmd=referral|padding=under256\r\n\r\n";
 
 fn resp(c: &mut Criterion) {
-    let mut headers = [httparse::Header{ name: "", value: &[] }; 16];
-    let mut resp = httparse::Response::new(&mut headers);
-
     c.benchmark_group("resp")
         .throughput(Throughput::Bytes(RESP.len() as u64))
-        .bench_function("resp", |b| b.iter(|| {
-            assert_eq!(black_box(resp.parse(RESP).unwrap()), httparse::Status::Complete(RESP.len()));
-        }));
+        .bench_function("resp", |b| b.iter_batched_ref(|| {
+            [httparse::Header {
+                name: "",
+                value: &[],
+            }; 16]
+        }, |headers| {
+            let mut resp = httparse::Response::new(headers);
+            assert_eq!(
+                resp.parse(black_box(RESP)).unwrap(),
+                httparse::Status::Complete(RESP.len())
+            );
+        }, BatchSize::SmallInput));
 }
 
 fn resp_short(c: &mut Criterion) {
-    let mut headers = [httparse::Header{ name: "", value: &[] }; 16];
-    let mut resp = httparse::Response::new(&mut headers);
-
     c.benchmark_group("resp_short")
         .throughput(Throughput::Bytes(RESP_SHORT.len() as u64))
-        .bench_function("resp_short", |b| b.iter(|| {
-            assert_eq!(black_box(resp.parse(RESP_SHORT).unwrap()), httparse::Status::Complete(RESP_SHORT.len()));
-        }));
+        .bench_function("resp_short", |b| b.iter_batched_ref(|| {
+            [httparse::Header {
+                name: "",
+                value: &[],
+            }; 16]
+        },
+        |headers| {
+            let mut resp = httparse::Response::new(headers);
+            assert_eq!(
+                resp.parse(black_box(RESP_SHORT)).unwrap(),
+                httparse::Status::Complete(RESP_SHORT.len())
+            );
+        }, BatchSize::SmallInput));
 }
 
 fn uri(c: &mut Criterion) {
@@ -88,17 +112,15 @@ fn uri(c: &mut Criterion) {
         c.benchmark_group("uri")
         .throughput(Throughput::Bytes(input.len() as u64))
         .bench_function(name, |b| b.iter(|| {
-            black_box({
-                let mut b = httparse::_benchable::Bytes::new(input);
-                httparse::_benchable::parse_uri(&mut b).unwrap()
-            });
+            let mut b = httparse::_benchable::Bytes::new(black_box(input));
+            httparse::_benchable::parse_uri(&mut b).unwrap()
         }));
     }
 
     const S: &[u8] = b" ";
     const CHUNK64: &[u8] = b"/wp-content/uploads/2022/08/31/hello-kitty-darth-vader-pink.webp";
     let chunk_4k = CHUNK64.repeat(64);
-    
+
     // 1b to 4096b
     for p in 0..=12 {
         let n = 1 << p;
@@ -108,37 +130,34 @@ fn uri(c: &mut Criterion) {
 
 fn header(c: &mut Criterion) {
     fn _header(c: &mut Criterion, name: &str, input: &'static [u8]) {
-        let mut headers = [httparse::EMPTY_HEADER; 128];
         c.benchmark_group("header")
         .throughput(Throughput::Bytes(input.len() as u64))
-        .bench_function(name, |b| b.iter(|| {
-            {
-                let _ = httparse::parse_headers(input, &mut headers).unwrap();
-            };
-            black_box(());
-        }));
+        .bench_function(name, |b| b.iter_batched_ref(|| [httparse::EMPTY_HEADER; 128],|headers| {
+            let status = httparse::parse_headers(black_box(input), headers).unwrap();
+            black_box(status.unwrap()).0
+        }, BatchSize::SmallInput));
     }
-        
+
     const RN: &[u8] = b"\r\n";
     const RNRN: &[u8] = b"\r\n\r\n";
     const TINY_RN: &[u8] = b"a: b\r\n"; // minimal header line
     const XFOOBAR: &[u8] = b"X-Foobar";
     let xfoobar_4k = XFOOBAR.repeat(4096/XFOOBAR.len());
-    
+
     // header names 1b to 4096b
     for p in 0..=12 {
         let n = 1 << p;
         let payload = [&xfoobar_4k[..n], b": b", RNRN].concat().leak();
         _header(c, &format!("name_{}b", n), payload);
     }
-    
+
     // header values 1b to 4096b
     for p in 0..=12 {
         let n = 1 << p;
         let payload = [b"a: ", &xfoobar_4k[..n], RNRN].concat().leak();
         _header(c, &format!("value_{}b", n), payload);
     }
-    
+
     // 1 to 128
     for p in 0..=7 {
         let n = 1 << p;
@@ -151,13 +170,11 @@ fn version(c: &mut Criterion) {
         c.benchmark_group("version")
         .throughput(Throughput::Bytes(input.len() as u64))
         .bench_function(name, |b| b.iter(|| {
-            black_box({
-                let mut b = httparse::_benchable::Bytes::new(input);
-                httparse::_benchable::parse_version(&mut b).unwrap()
-            });
+            let mut b = httparse::_benchable::Bytes::new(black_box(input));
+            httparse::_benchable::parse_version(&mut b).unwrap()
         }));
     }
-    
+
     _version(c, "http10", b"HTTP/1.0\r\n");
     _version(c, "http11", b"HTTP/1.1\r\n");
     _version(c, "partial", b"HTTP/1.");
@@ -168,13 +185,11 @@ fn method(c: &mut Criterion) {
         c.benchmark_group("method")
         .throughput(Throughput::Bytes(input.len() as u64))
         .bench_function(name, |b| b.iter(|| {
-            black_box({
-                let mut b = httparse::_benchable::Bytes::new(input);
-                httparse::_benchable::parse_method(&mut b).unwrap()
-            });
+            let mut b = httparse::_benchable::Bytes::new(black_box(input));
+            httparse::_benchable::parse_method(&mut b).unwrap()
         }));
     }
-    
+
     // Common methods should be fast-pathed
     const COMMON_METHODS: &[&str] = &["GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH"];
     for method in COMMON_METHODS {


### PR DESCRIPTION
This has the effect of slowing down many of the benchmarks, which implies that the compiler has been able to constant-fold some of the computations.

I'm submitting this as its own PR, as any future changes (of which I have one pending) should be evaluated based on these more complete benchmarks, rather than on how well the compiler can constant fold after the changes.

I ran both before and after with Criterion default settings, as my hardware gives more consistent results with the defaults.  This is what I got:

```
req/req                 time:   [195.98 ns 197.50 ns 199.22 ns]
                        thrpt:  [3.3658 GiB/s 3.3952 GiB/s 3.4215 GiB/s]
                 change:
                        time:   [+1.5871% +2.6429% +3.7379%] (p = 0.00 < 0.05)
                        thrpt:  [-3.6032% -2.5749% -1.5623%]
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

req_short/req_short     time:   [55.029 ns 55.351 ns 55.706 ns]
                        thrpt:  [1.1369 GiB/s 1.1442 GiB/s 1.1509 GiB/s]
                 change:
                        time:   [+2.8583% +4.3521% +6.2387%] (p = 0.00 < 0.05)
                        thrpt:  [-5.8724% -4.1706% -2.7789%]
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) high mild
  6 (6.00%) high severe

resp/resp               time:   [220.45 ns 222.00 ns 223.70 ns]
                        thrpt:  [2.9101 GiB/s 2.9324 GiB/s 2.9530 GiB/s]
                 change:
                        time:   [+2.6997% +5.4173% +7.9621%] (p = 0.00 < 0.05)
                        thrpt:  [-7.3749% -5.1389% -2.6287%]
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe

resp_short/resp_short   time:   [62.541 ns 63.220 ns 64.086 ns]
                        thrpt:  [1.3225 GiB/s 1.3406 GiB/s 1.3551 GiB/s]
                 change:
                        time:   [+9.7428% +11.335% +12.925%] (p = 0.00 < 0.05)
                        thrpt:  [-11.446% -10.181% -8.8779%]
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

uri/uri_1b              time:   [7.6483 ns 7.6945 ns 7.7414 ns]
                        thrpt:  [246.38 MiB/s 247.88 MiB/s 249.38 MiB/s]
                 change:
                        time:   [-10.077% -8.8089% -7.4882%] (p = 0.00 < 0.05)
                        thrpt:  [+8.0943% +9.6598% +11.207%]
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  7 (7.00%) high mild
  2 (2.00%) high severe

uri/uri_2b              time:   [8.8387 ns 8.9159 ns 9.0066 ns]
                        thrpt:  [317.66 MiB/s 320.89 MiB/s 323.69 MiB/s]
                 change:
                        time:   [-7.1592% -5.9088% -4.6594%] (p = 0.00 < 0.05)
                        thrpt:  [+4.8871% +6.2798% +7.7113%]
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  6 (6.00%) high mild

uri/uri_4b              time:   [11.389 ns 11.474 ns 11.569 ns]
                        thrpt:  [412.16 MiB/s 415.57 MiB/s 418.69 MiB/s]
                 change:
                        time:   [-10.253% -8.6526% -6.9183%] (p = 0.00 < 0.05)
                        thrpt:  [+7.4326% +9.4722% +11.425%]
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe

uri/uri_8b              time:   [7.8342 ns 7.9153 ns 7.9946 ns]
                        thrpt:  [1.0484 GiB/s 1.0589 GiB/s 1.0699 GiB/s]
                 change:
                        time:   [-2.7092% -1.3560% -0.0760%] (p = 0.05 < 0.05)
                        thrpt:  [+0.0761% +1.3747% +2.7846%]
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe

uri/uri_16b             time:   [7.7853 ns 7.8477 ns 7.9136 ns]
                        thrpt:  [2.0007 GiB/s 2.0175 GiB/s 2.0336 GiB/s]
                 change:
                        time:   [-3.6370% -2.4811% -1.3124%] (p = 0.00 < 0.05)
                        thrpt:  [+1.3299% +2.5442% +3.7743%]
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

uri/uri_32b             time:   [8.9342 ns 9.1105 ns 9.3290 ns]
                        thrpt:  [3.2944 GiB/s 3.3734 GiB/s 3.4400 GiB/s]
                 change:
                        time:   [+7.0261% +8.4307% +10.097%] (p = 0.00 < 0.05)
                        thrpt:  [-9.1713% -7.7752% -6.5649%]
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  2 (2.00%) high severe

uri/uri_64b             time:   [9.5725 ns 9.6548 ns 9.7418 ns]
                        thrpt:  [6.2141 GiB/s 6.2700 GiB/s 6.3240 GiB/s]
                 change:
                        time:   [+2.8028% +3.9402% +5.1538%] (p = 0.00 < 0.05)
                        thrpt:  [-4.9012% -3.7908% -2.7264%]
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

uri/uri_128b            time:   [12.783 ns 12.913 ns 13.062 ns]
                        thrpt:  [9.1980 GiB/s 9.3035 GiB/s 9.3988 GiB/s]
                 change:
                        time:   [+0.1576% +1.9200% +3.7236%] (p = 0.04 < 0.05)
                        thrpt:  [-3.5900% -1.8838% -0.1573%]
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

uri/uri_256b            time:   [18.376 ns 18.607 ns 18.937 ns]
                        thrpt:  [12.639 GiB/s 12.863 GiB/s 13.025 GiB/s]
                 change:
                        time:   [-1.6437% -0.2622% +1.0770%] (p = 0.71 > 0.05)
                        thrpt:  [-1.0656% +0.2629% +1.6712%]
                        No change in performance detected.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  5 (5.00%) high severe

uri/uri_512b            time:   [29.945 ns 30.531 ns 31.424 ns]
                        thrpt:  [15.204 GiB/s 15.649 GiB/s 15.955 GiB/s]
                 change:
                        time:   [+0.1892% +1.8323% +3.4885%] (p = 0.03 < 0.05)
                        thrpt:  [-3.3709% -1.7994% -0.1888%]
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe

uri/uri_1024b           time:   [52.580 ns 52.987 ns 53.395 ns]
                        thrpt:  [17.878 GiB/s 18.016 GiB/s 18.155 GiB/s]
                 change:
                        time:   [-1.4192% -0.4498% +0.5078%] (p = 0.37 > 0.05)
                        thrpt:  [-0.5053% +0.4519% +1.4397%]
                        No change in performance detected.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

uri/uri_2048b           time:   [98.872 ns 99.381 ns 99.884 ns]
                        thrpt:  [19.105 GiB/s 19.202 GiB/s 19.301 GiB/s]
                 change:
                        time:   [-1.0783% -0.2271% +0.6214%] (p = 0.61 > 0.05)
                        thrpt:  [-0.6176% +0.2276% +1.0900%]
                        No change in performance detected.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

uri/uri_4096b           time:   [201.69 ns 203.42 ns 205.20 ns]
                        thrpt:  [18.595 GiB/s 18.757 GiB/s 18.918 GiB/s]
                 change:
                        time:   [+1.8642% +3.1006% +4.2146%] (p = 0.00 < 0.05)
                        thrpt:  [-4.0442% -3.0073% -1.8301%]
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

header/name_1b          time:   [31.637 ns 32.303 ns 33.035 ns]
                        thrpt:  [230.95 MiB/s 236.18 MiB/s 241.16 MiB/s]
                 change:
                        time:   [+47.708% +51.142% +54.754%] (p = 0.00 < 0.05)
                        thrpt:  [-35.381% -33.837% -32.299%]
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

header/name_2b          time:   [31.112 ns 31.697 ns 32.350 ns]
                        thrpt:  [265.32 MiB/s 270.78 MiB/s 275.87 MiB/s]
                 change:
                        time:   [+48.443% +52.092% +55.313%] (p = 0.00 < 0.05)
                        thrpt:  [-35.614% -34.250% -32.634%]
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

header/name_4b          time:   [31.641 ns 32.238 ns 32.834 ns]
                        thrpt:  [319.50 MiB/s 325.41 MiB/s 331.54 MiB/s]
                 change:
                        time:   [+37.774% +40.798% +44.241%] (p = 0.00 < 0.05)
                        thrpt:  [-30.672% -28.976% -27.417%]
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

header/name_8b          time:   [33.950 ns 34.499 ns 35.059 ns]
                        thrpt:  [408.03 MiB/s 414.65 MiB/s 421.36 MiB/s]
                 change:
                        time:   [+38.915% +42.292% +45.785%] (p = 0.00 < 0.05)
                        thrpt:  [-31.406% -29.722% -28.014%]
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

header/name_16b         time:   [36.522 ns 37.236 ns 37.960 ns]
                        thrpt:  [577.83 MiB/s 589.07 MiB/s 600.58 MiB/s]
                 change:
                        time:   [+29.207% +32.169% +35.405%] (p = 0.00 < 0.05)
                        thrpt:  [-26.148% -24.339% -22.605%]
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

header/name_32b         time:   [42.358 ns 42.791 ns 43.266 ns]
                        thrpt:  [859.64 MiB/s 869.19 MiB/s 878.07 MiB/s]
                 change:
                        time:   [+22.435% +25.703% +28.865%] (p = 0.00 < 0.05)
                        thrpt:  [-22.399% -20.447% -18.324%]
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

header/name_64b         time:   [57.531 ns 58.071 ns 58.718 ns]
                        thrpt:  [1.1261 GiB/s 1.1387 GiB/s 1.1494 GiB/s]
                 change:
                        time:   [+16.957% +19.237% +21.691%] (p = 0.00 < 0.05)
                        thrpt:  [-17.825% -16.134% -14.498%]
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  6 (6.00%) high mild

header/name_128b        time:   [88.739 ns 89.566 ns 90.457 ns]
                        thrpt:  [1.3899 GiB/s 1.4038 GiB/s 1.4168 GiB/s]
                 change:
                        time:   [+18.014% +20.418% +22.997%] (p = 0.00 < 0.05)
                        thrpt:  [-18.697% -16.956% -15.264%]
                        Performance has regressed.
Found 11 outliers among 100 measurements (11.00%)
  9 (9.00%) high mild
  2 (2.00%) high severe

header/name_256b        time:   [153.91 ns 154.97 ns 156.12 ns]
                        thrpt:  [1.5689 GiB/s 1.5805 GiB/s 1.5914 GiB/s]
                 change:
                        time:   [+2.6028% +6.8818% +10.836%] (p = 0.00 < 0.05)
                        thrpt:  [-9.7767% -6.4387% -2.5368%]
                        Performance has regressed.
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) high mild
  8 (8.00%) high severe

header/name_512b        time:   [280.47 ns 283.48 ns 287.14 ns]
                        thrpt:  [1.6833 GiB/s 1.7051 GiB/s 1.7234 GiB/s]
                 change:
                        time:   [+9.7113% +11.941% +14.635%] (p = 0.00 < 0.05)
                        thrpt:  [-12.766% -10.667% -8.8517%]
                        Performance has regressed.
Found 11 outliers among 100 measurements (11.00%)
  5 (5.00%) high mild
  6 (6.00%) high severe

header/name_1024b       time:   [538.28 ns 542.80 ns 547.31 ns]
                        thrpt:  [1.7544 GiB/s 1.7690 GiB/s 1.7838 GiB/s]
                 change:
                        time:   [+11.592% +13.651% +15.538%] (p = 0.00 < 0.05)
                        thrpt:  [-13.448% -12.011% -10.388%]
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe

header/name_2048b       time:   [1.0486 µs 1.0569 µs 1.0648 µs]
                        thrpt:  [1.7974 GiB/s 1.8109 GiB/s 1.8252 GiB/s]
                 change:
                        time:   [+9.9649% +11.410% +12.913%] (p = 0.00 < 0.05)
                        thrpt:  [-11.437% -10.241% -9.0619%]
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) high mild
  5 (5.00%) high severe

header/name_4096b       time:   [2.0378 µs 2.0515 µs 2.0657 µs]
                        thrpt:  [1.8498 GiB/s 1.8626 GiB/s 1.8752 GiB/s]
                 change:
                        time:   [+5.3977% +6.4892% +7.4972%] (p = 0.00 < 0.05)
                        thrpt:  [-6.9744% -6.0938% -5.1213%]
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

header/value_1b         time:   [30.076 ns 30.841 ns 31.676 ns]
                        thrpt:  [240.86 MiB/s 247.38 MiB/s 253.67 MiB/s]
                 change:
                        time:   [+38.846% +42.246% +45.739%] (p = 0.00 < 0.05)
                        thrpt:  [-31.384% -29.699% -27.978%]
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

header/value_2b         time:   [32.778 ns 33.494 ns 34.258 ns]
                        thrpt:  [250.54 MiB/s 256.25 MiB/s 261.85 MiB/s]
                 change:
                        time:   [+51.132% +54.485% +57.770%] (p = 0.00 < 0.05)
                        thrpt:  [-36.617% -35.269% -33.832%]
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

header/value_4b         time:   [32.099 ns 32.742 ns 33.374 ns]
                        thrpt:  [314.33 MiB/s 320.40 MiB/s 326.81 MiB/s]
                 change:
                        time:   [+27.935% +31.139% +34.108%] (p = 0.00 < 0.05)
                        thrpt:  [-25.433% -23.745% -21.836%]
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

header/value_8b         time:   [32.038 ns 32.516 ns 32.977 ns]
                        thrpt:  [433.80 MiB/s 439.95 MiB/s 446.50 MiB/s]
                 change:
                        time:   [+29.970% +33.256% +36.422%] (p = 0.00 < 0.05)
                        thrpt:  [-26.698% -24.957% -23.059%]
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

header/value_16b        time:   [30.973 ns 31.629 ns 32.323 ns]
                        thrpt:  [678.60 MiB/s 693.50 MiB/s 708.18 MiB/s]
                 change:
                        time:   [+52.015% +56.427% +61.037%] (p = 0.00 < 0.05)
                        thrpt:  [-37.902% -36.072% -34.217%]
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

header/value_32b        time:   [28.588 ns 29.086 ns 29.606 ns]
                        thrpt:  [1.2268 GiB/s 1.2488 GiB/s 1.2705 GiB/s]
                 change:
                        time:   [+30.038% +32.446% +34.879%] (p = 0.00 < 0.05)
                        thrpt:  [-25.859% -24.498% -23.100%]
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

header/value_64b        time:   [30.388 ns 30.996 ns 31.614 ns]
                        thrpt:  [2.0916 GiB/s 2.1333 GiB/s 2.1760 GiB/s]
                 change:
                        time:   [+44.771% +48.810% +53.349%] (p = 0.00 < 0.05)
                        thrpt:  [-34.789% -32.800% -30.925%]
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

header/value_128b       time:   [34.093 ns 34.568 ns 35.074 ns]
                        thrpt:  [3.5847 GiB/s 3.6371 GiB/s 3.6878 GiB/s]
                 change:
                        time:   [+36.353% +39.561% +42.723%] (p = 0.00 < 0.05)
                        thrpt:  [-29.934% -28.347% -26.661%]
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

header/value_256b       time:   [39.368 ns 40.306 ns 41.333 ns]
                        thrpt:  [5.9259 GiB/s 6.0769 GiB/s 6.2217 GiB/s]
                 change:
                        time:   [+28.330% +31.242% +34.421%] (p = 0.00 < 0.05)
                        thrpt:  [-25.607% -23.805% -22.076%]
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

header/value_512b       time:   [53.001 ns 53.659 ns 54.396 ns]
                        thrpt:  [8.8859 GiB/s 9.0080 GiB/s 9.1198 GiB/s]
                 change:
                        time:   [+20.351% +22.663% +25.076%] (p = 0.00 < 0.05)
                        thrpt:  [-20.048% -18.476% -16.910%]
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe

header/value_1024b      time:   [83.973 ns 84.975 ns 86.019 ns]
                        thrpt:  [11.163 GiB/s 11.300 GiB/s 11.435 GiB/s]
                 change:
                        time:   [+18.143% +20.849% +23.785%] (p = 0.00 < 0.05)
                        thrpt:  [-19.214% -17.252% -15.357%]
                        Performance has regressed.
Found 11 outliers among 100 measurements (11.00%)
  8 (8.00%) high mild
  3 (3.00%) high severe

header/value_2048b      time:   [163.95 ns 165.12 ns 166.29 ns]
                        thrpt:  [11.509 GiB/s 11.591 GiB/s 11.673 GiB/s]
                 change:
                        time:   [+20.837% +22.747% +24.834%] (p = 0.00 < 0.05)
                        thrpt:  [-19.894% -18.532% -17.244%]
                        Performance has regressed.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) high mild
  8 (8.00%) high severe

header/value_4096b      time:   [282.86 ns 286.56 ns 290.66 ns]
                        thrpt:  [13.147 GiB/s 13.335 GiB/s 13.509 GiB/s]
                 change:
                        time:   [+16.762% +18.707% +20.703%] (p = 0.00 < 0.05)
                        thrpt:  [-17.152% -15.759% -14.356%]
                        Performance has regressed.
Found 11 outliers among 100 measurements (11.00%)
  4 (4.00%) high mild
  7 (7.00%) high severe

header/count_1          time:   [29.968 ns 30.537 ns 31.135 ns]
                        thrpt:  [245.04 MiB/s 249.84 MiB/s 254.59 MiB/s]
                 change:
                        time:   [+38.530% +41.550% +44.544%] (p = 0.00 < 0.05)
                        thrpt:  [-30.817% -29.354% -27.813%]
                        Performance has regressed.

header/count_2          time:   [40.585 ns 41.181 ns 41.872 ns]
                        thrpt:  [318.87 MiB/s 324.22 MiB/s 328.98 MiB/s]
                 change:
                        time:   [+19.015% +23.869% +29.886%] (p = 0.00 < 0.05)
                        thrpt:  [-23.009% -19.270% -15.977%]
                        Performance has regressed.
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe

header/count_4          time:   [68.182 ns 69.935 ns 72.325 ns]
                        thrpt:  [342.83 MiB/s 354.55 MiB/s 363.67 MiB/s]
                 change:
                        time:   [+16.322% +19.540% +23.122%] (p = 0.00 < 0.05)
                        thrpt:  [-18.780% -16.346% -14.032%]
                        Performance has regressed.
Found 15 outliers among 100 measurements (15.00%)
  11 (11.00%) high mild
  4 (4.00%) high severe

header/count_8          time:   [116.76 ns 117.72 ns 118.70 ns]
                        thrpt:  [401.71 MiB/s 405.05 MiB/s 408.41 MiB/s]
                 change:
                        time:   [+6.7980% +8.7362% +10.711%] (p = 0.00 < 0.05)
                        thrpt:  [-9.6743% -8.0343% -6.3653%]
                        Performance has regressed.
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) high mild
  6 (6.00%) high severe

header/count_16         time:   [225.12 ns 227.12 ns 229.34 ns]
                        thrpt:  [407.53 MiB/s 411.49 MiB/s 415.16 MiB/s]
                 change:
                        time:   [+2.9178% +5.2150% +7.2666%] (p = 0.00 < 0.05)
                        thrpt:  [-6.7744% -4.9565% -2.8351%]
                        Performance has regressed.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  5 (5.00%) high severe

header/count_32         time:   [414.01 ns 416.66 ns 419.44 ns]
                        thrpt:  [441.10 MiB/s 444.04 MiB/s 446.88 MiB/s]
                 change:
                        time:   [-0.3625% +1.3742% +3.4561%] (p = 0.14 > 0.05)
                        thrpt:  [-3.3406% -1.3555% +0.3638%]
                        No change in performance detected.
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) high mild
  7 (7.00%) high severe

header/count_64         time:   [786.31 ns 791.17 ns 795.93 ns]
                        thrpt:  [462.50 MiB/s 465.28 MiB/s 468.16 MiB/s]
                 change:
                        time:   [+2.3510% +3.8775% +5.5443%] (p = 0.00 < 0.05)
                        thrpt:  [-5.2531% -3.7327% -2.2970%]
                        Performance has regressed.
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) high mild
  8 (8.00%) high severe

header/count_128        time:   [1.5232 µs 1.5329 µs 1.5437 µs]
                        thrpt:  [475.70 MiB/s 479.04 MiB/s 482.08 MiB/s]
                 change:
                        time:   [-1.2641% -0.3277% +0.6343%] (p = 0.50 > 0.05)
                        thrpt:  [-0.6303% +0.3288% +1.2803%]
                        No change in performance detected.
Found 12 outliers among 100 measurements (12.00%)
  3 (3.00%) low mild
  5 (5.00%) high mild
  4 (4.00%) high severe

version/http10          time:   [988.09 ps 994.82 ps 1.0020 ns]
                        thrpt:  [9.2951 GiB/s 9.3617 GiB/s 9.4254 GiB/s]
                 change:
                        time:   [+104.82% +106.76% +108.79%] (p = 0.00 < 0.05)
                        thrpt:  [-52.106% -51.636% -51.178%]
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

version/http11          time:   [1.6726 ns 1.6861 ns 1.6996 ns]
                        thrpt:  [5.4795 GiB/s 5.5235 GiB/s 5.5681 GiB/s]
                 change:
                        time:   [+36.611% +37.884% +39.165%] (p = 0.00 < 0.05)
                        thrpt:  [-28.143% -27.476% -26.800%]
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

version/partial         time:   [4.6214 ns 4.6593 ns 4.7006 ns]
                        thrpt:  [1.3869 GiB/s 1.3992 GiB/s 1.4107 GiB/s]
                 change:
                        time:   [+59.975% +61.672% +63.278%] (p = 0.00 < 0.05)
                        thrpt:  [-38.755% -38.147% -37.490%]
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild

method/get              time:   [1.4326 ns 1.4513 ns 1.4742 ns]
                        thrpt:  [10.108 GiB/s 10.267 GiB/s 10.402 GiB/s]
                 change:
                        time:   [+98.709% +101.95% +105.37%] (p = 0.00 < 0.05)
                        thrpt:  [-51.308% -50.482% -49.675%]
                        Performance has regressed.
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) high mild
  8 (8.00%) high severe

method/head             time:   [4.8872 ns 4.9385 ns 4.9953 ns]
                        thrpt:  [3.1694 GiB/s 3.2059 GiB/s 3.2396 GiB/s]
                 change:
                        time:   [+49.062% +50.806% +52.837%] (p = 0.00 < 0.05)
                        thrpt:  [-34.571% -33.690% -32.914%]
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  3 (3.00%) high severe

method/post             time:   [2.8666 ns 2.8949 ns 2.9282 ns]
                        thrpt:  [5.4068 GiB/s 5.4692 GiB/s 5.5231 GiB/s]
                 change:
                        time:   [+200.49% +203.40% +206.33%] (p = 0.00 < 0.05)
                        thrpt:  [-67.355% -67.040% -66.721%]
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe

method/put              time:   [4.9647 ns 4.9946 ns 5.0267 ns]
                        thrpt:  [2.9644 GiB/s 2.9834 GiB/s 3.0014 GiB/s]
                 change:
                        time:   [+129.83% +132.17% +134.51%] (p = 0.00 < 0.05)
                        thrpt:  [-57.358% -56.927% -56.489%]
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

method/delete           time:   [6.1609 ns 6.1963 ns 6.2351 ns]
                        thrpt:  [2.8380 GiB/s 2.8558 GiB/s 2.8722 GiB/s]
                 change:
                        time:   [+80.460% +83.068% +85.650%] (p = 0.00 < 0.05)
                        thrpt:  [-46.135% -45.376% -44.586%]
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe

method/connect          time:   [6.8994 ns 6.9426 ns 6.9900 ns]
                        thrpt:  [2.6647 GiB/s 2.6829 GiB/s 2.6997 GiB/s]
                 change:
                        time:   [+76.513% +79.438% +81.688%] (p = 0.00 < 0.05)
                        thrpt:  [-44.960% -44.271% -43.347%]
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

method/options          time:   [6.9067 ns 6.9690 ns 7.0330 ns]
                        thrpt:  [2.6485 GiB/s 2.6728 GiB/s 2.6969 GiB/s]
                 change:
                        time:   [+78.136% +80.074% +82.055%] (p = 0.00 < 0.05)
                        thrpt:  [-45.072% -44.467% -43.863%]
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

method/trace            time:   [5.6663 ns 5.7057 ns 5.7548 ns]
                        thrpt:  [2.9130 GiB/s 2.9381 GiB/s 2.9585 GiB/s]
                 change:
                        time:   [+84.774% +87.368% +90.185%] (p = 0.00 < 0.05)
                        thrpt:  [-47.420% -46.629% -45.880%]
                        Performance has regressed.
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) low mild
  4 (4.00%) high mild
  1 (1.00%) high severe

method/patch            time:   [6.6594 ns 6.7016 ns 6.7470 ns]
                        thrpt:  [2.4846 GiB/s 2.5015 GiB/s 2.5173 GiB/s]
                 change:
                        time:   [+107.51% +110.77% +113.43%] (p = 0.00 < 0.05)
                        thrpt:  [-53.146% -52.555% -51.810%]
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

method/custom           time:   [6.3452 ns 6.3922 ns 6.4380 ns]
                        thrpt:  [2.7485 GiB/s 2.7682 GiB/s 2.7887 GiB/s]
                 change:
                        time:   [+89.196% +91.488% +94.050%] (p = 0.00 < 0.05)
                        thrpt:  [-48.467% -47.777% -47.145%]
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
```