### PR TITLE
add option to save partial header value

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2238,6 +2238,22 @@ mod tests {
         assert_eq!(req.headers[1].value, b"a=b;def=c");
     }
 
+    #[test]
+    fn test_response_with_save_partial_header_value_partial_ctl() {
+        let mut headers = [EMPTY_HEADER; NUM_OF_HEADERS];
+        let mut res = Response::new(&mut headers[..]);
+        let result =  crate::ParserConfig::default()
+            .save_partial_header_value(true)
+            .parse_response(&mut res, b"HTTP/1.1 200 OK\r\nBread: baguette");
+        assert_eq!(result, Ok(Status::Partial));
+        assert_eq!(res.code.unwrap(), 200);
+        assert_eq!(res.reason.unwrap(), "OK");
+        assert_eq!(res.version.unwrap(), 1);
+        assert_eq!(res.headers.len(), NUM_OF_HEADERS);
+        assert_eq!(res.headers[0].name, "Bread");
+        assert_eq!(res.headers[0].value, b"baguette");
+    }
+
     static RESPONSE_WITH_SPACES_IN_CODE: &[u8] = b"HTTP/1.1 99 200 OK\r\n\r\n";
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2239,12 +2239,28 @@ mod tests {
     }
 
     #[test]
-    fn test_response_with_save_partial_header_value_partial_ctl() {
+    fn test_response_with_save_partial_header_value() {
         let mut headers = [EMPTY_HEADER; NUM_OF_HEADERS];
         let mut res = Response::new(&mut headers[..]);
         let result =  crate::ParserConfig::default()
             .save_partial_header_value(true)
             .parse_response(&mut res, b"HTTP/1.1 200 OK\r\nBread: baguette");
+        assert_eq!(result, Ok(Status::Partial));
+        assert_eq!(res.code.unwrap(), 200);
+        assert_eq!(res.reason.unwrap(), "OK");
+        assert_eq!(res.version.unwrap(), 1);
+        assert_eq!(res.headers.len(), NUM_OF_HEADERS);
+        assert_eq!(res.headers[0].name, "Bread");
+        assert_eq!(res.headers[0].value, b"baguette");
+    }
+
+    #[test]
+    fn test_response_with_save_partial_header_value_partial_ctl() {
+        let mut headers = [EMPTY_HEADER; NUM_OF_HEADERS];
+        let mut res = Response::new(&mut headers[..]);
+        let result =  crate::ParserConfig::default()
+            .save_partial_header_value(true)
+            .parse_response(&mut res, b"HTTP/1.1 200 OK\r\nBread: baguette\r");
         assert_eq!(result, Ok(Status::Partial));
         assert_eq!(res.code.unwrap(), 200);
         assert_eq!(res.reason.unwrap(), "OK");


### PR DESCRIPTION
Hello @seanmonstar,

Thanks for this great crate. I'm using this as the basic parser for http data analysis. I want to get as much as information even though the http date is not complete. So i create this PR to add an option to save partial header value. 

Hope you can review this code.