### PR TITLE
simd: split cursor advancing from value matching

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -953,18 +953,20 @@ fn parse_token<'a>(bytes: &mut Bytes<'a>) -> Result<&'a str> {
 #[allow(missing_docs)]
 // WARNING: Exported for internal benchmarks, not fit for public consumption
 pub fn parse_uri<'a>(bytes: &mut Bytes<'a>) -> Result<&'a str> {
-    let start = bytes.pos();
-    simd::match_uri_vectored(bytes);
     // URI must have at least one char
-    if bytes.pos() == start {
+    let uri_len = simd::match_uri_vectored(bytes.as_ref());
+    if uri_len == 0 {
         return Err(Error::Token);
     }
+    // SAFETY: these bytes have just been matched here above.
+    unsafe { bytes.advance(uri_len) };
+    let uri_slice = bytes.slice();
 
-    if next!(bytes) == b' ' {
-        return Ok(Status::Complete(
-            // SAFETY: all bytes up till `i` must have been `is_token` and therefore also utf-8.
-            unsafe { str::from_utf8_unchecked(bytes.slice_skip(1)) },
-        ));
+    let space_delim = next!(bytes);
+    if space_delim == b' ' {
+        // SAFETY: all bytes within `uri_slice` must have been `is_token` and therefore also utf-8.
+        let uri = unsafe { str::from_utf8_unchecked(uri_slice) };
+        Ok(Status::Complete(uri))
     } else {
         Err(Error::Token)
     }
@@ -1179,15 +1181,15 @@ fn parse_headers_iter_uninit<'a>(
         #[allow(clippy::never_loop)]
         // parse header name until colon
         let header_name: &str = 'name: loop {
-            simd::match_header_name_vectored(bytes);
-            let mut b = next!(bytes);
-
-            // SAFETY: previously bumped by 1 with next! -> always safe.
-            let bslice = unsafe { bytes.slice_skip(1) };
+            let len = simd::match_header_name_vectored(bytes.as_ref());
+            // SAFETY: these bytes have just been matched here above.
+            unsafe { bytes.advance(len) };
+            let bslice = bytes.slice();
             // SAFETY: previous call to match_header_name_vectored ensured all bytes are valid
             // header name chars, and as such also valid utf-8.
             let name = unsafe { str::from_utf8_unchecked(bslice) };
 
+            let mut b = next!(bytes);
             if b == b':' {
                 break 'name name;
             }
@@ -1213,6 +1215,7 @@ fn parse_headers_iter_uninit<'a>(
             // eat white space between colon and value
             'whitespace_after_colon: loop {
                 b = next!(bytes);
+
                 if b == b' ' || b == b'\t' {
                     bytes.slice();
                     continue 'whitespace_after_colon;
@@ -1239,7 +1242,9 @@ fn parse_headers_iter_uninit<'a>(
             'value_lines: loop {
                 // parse value till EOL
 
-                simd::match_header_value_vectored(bytes);
+                let len = simd::match_header_value_vectored(bytes.as_ref());
+                // SAFETY: these bytes have just been matched here above.
+                unsafe { bytes.advance(len) };
                 let b = next!(bytes);
 
                 //found_ctl

--- a/src/simd/mod.rs
+++ b/src/simd/mod.rs
@@ -11,7 +11,7 @@ mod swar;
         )
     ),
 )))]
-pub use self::swar::*;
+pub(crate) use self::swar::*;
 
 #[cfg(all(
     httparse_simd,
@@ -59,7 +59,7 @@ mod runtime;
         target_arch = "x86_64",
     ),
 ))]
-pub use self::runtime::*;
+pub(crate) use self::runtime::*;
 
 #[cfg(all(
     httparse_simd,
@@ -72,18 +72,18 @@ pub use self::runtime::*;
 ))]
 mod sse42_compile_time {
     #[inline(always)]
-    pub fn match_header_name_vectored(b: &mut crate::iter::Bytes<'_>) {
-        super::swar::match_header_name_vectored(b);
+    pub(crate) fn match_header_name_vectored(b: &[u8]) -> usize {
+        super::swar::match_header_name_vectored(b)
     }
 
     #[inline(always)]
-    pub fn match_uri_vectored(b: &mut crate::iter::Bytes<'_>) {
+    pub(crate) fn match_uri_vectored(b: &[u8]) -> usize {
         // SAFETY: calls are guarded by a compile time feature check
         unsafe { crate::simd::sse42::match_uri_vectored(b) }
     }
-    
+
     #[inline(always)]
-    pub fn match_header_value_vectored(b: &mut crate::iter::Bytes<'_>) {
+    pub(crate) fn match_header_value_vectored(b: &[u8]) -> usize {
         // SAFETY: calls are guarded by a compile time feature check
         unsafe { crate::simd::sse42::match_header_value_vectored(b) }
     }
@@ -98,7 +98,7 @@ mod sse42_compile_time {
         target_arch = "x86_64",
     ),
 ))]
-pub use self::sse42_compile_time::*;
+pub(crate) use self::sse42_compile_time::*;
 
 #[cfg(all(
     httparse_simd,
@@ -110,18 +110,18 @@ pub use self::sse42_compile_time::*;
 ))]
 mod avx2_compile_time {
     #[inline(always)]
-    pub fn match_header_name_vectored(b: &mut crate::iter::Bytes<'_>) {
-        super::swar::match_header_name_vectored(b);
+    pub(crate) fn match_header_name_vectored(b: &[u8]) -> usize {
+        super::swar::match_header_name_vectored(b)
     }
 
     #[inline(always)]
-    pub fn match_uri_vectored(b: &mut crate::iter::Bytes<'_>) {
+    pub(crate) fn match_uri_vectored(b: &[u8]) -> usize {
         // SAFETY: calls are guarded by a compile time feature check
         unsafe { crate::simd::avx2::match_uri_vectored(b) }
     }
-    
+
     #[inline(always)]
-    pub fn match_header_value_vectored(b: &mut crate::iter::Bytes<'_>) {
+    pub(crate) fn match_header_value_vectored(b: &[u8]) -> usize {
         // SAFETY: calls are guarded by a compile time feature check
         unsafe { crate::simd::avx2::match_header_value_vectored(b) }
     }
@@ -135,7 +135,7 @@ mod avx2_compile_time {
         target_arch = "x86_64",
     ),
 ))]
-pub use self::avx2_compile_time::*;
+pub(crate) use self::avx2_compile_time::*;
 
 #[cfg(all(
     httparse_simd,
@@ -149,4 +149,4 @@ mod neon;
     target_arch = "aarch64",
     httparse_simd_neon_intrinsics,
 ))]
-pub use self::neon::*;
+pub(crate) use self::neon::*;

--- a/src/simd/runtime.rs
+++ b/src/simd/runtime.rs
@@ -1,5 +1,5 @@
 use std::sync::atomic::{AtomicU8, Ordering};
-use crate::iter::Bytes;
+
 use super::avx2;
 use super::sse42;
 
@@ -30,11 +30,11 @@ fn get_runtime_feature() -> u8 {
     feature
 }
 
-pub fn match_header_name_vectored(bytes: &mut Bytes) {
-    super::swar::match_header_name_vectored(bytes);
+pub(crate) fn match_header_name_vectored(bytes: &[u8]) -> usize {
+    super::swar::match_header_name_vectored(bytes)
 }
 
-pub fn match_uri_vectored(bytes: &mut Bytes) {
+pub(crate) fn match_uri_vectored(bytes: &[u8]) -> usize {
     // SAFETY: calls are guarded by a feature check
     unsafe {
         match get_runtime_feature() {
@@ -45,7 +45,7 @@ pub fn match_uri_vectored(bytes: &mut Bytes) {
     }
 }
 
-pub fn match_header_value_vectored(bytes: &mut Bytes) {
+pub(crate) fn match_header_value_vectored(bytes: &[u8]) -> usize {
     // SAFETY: calls are guarded by a feature check
     unsafe {
         match get_runtime_feature() {


### PR DESCRIPTION
This refactors all SIMD modules in order to make the value-matching logic self-contained. Thus, all bytes-cursor manipulations are now grouped and performed once at the end, outside of SIMD logic.

Performance impact on my AVX2-capable workstation seems positive (arbitrary benchmark-noise filtering at >20%):

![critcmp](https://github.com/seanmonstar/httparse/assets/98086/4cb67196-58cd-4493-a8ab-f50d7f4f241c)
