### PR TITLE
Add `ParserConfig` accessors, convenience methods, and request parsing options

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,6 +255,7 @@ impl<T> Status<T> {
 /// Parser configuration.
 #[derive(Clone, Debug, Default)]
 pub struct ParserConfig {
+    allow_spaces_after_header_name_in_requests: bool,
     allow_spaces_after_header_name_in_responses: bool,
     allow_obsolete_multiline_headers_in_responses: bool,
     allow_multiple_spaces_in_request_line_delimiters: bool,
@@ -265,6 +266,20 @@ pub struct ParserConfig {
 }
 
 impl ParserConfig {
+    /// Sets whether spaces and tabs should be allowed after header names in requests.
+    pub fn allow_spaces_after_header_name_in_requests(
+        &mut self,
+        value: bool,
+    ) -> &mut Self {
+        self.allow_spaces_after_header_name_in_requests = value;
+        self
+    }
+
+    /// Whether spaces and tabs should be allowed after header names in requests.
+    pub fn spaces_after_header_name_in_requests_are_allowed(&self) -> bool {
+        self.allow_spaces_after_header_name_in_requests
+    }
+
     /// Sets whether spaces and tabs should be allowed after header names in responses.
     pub fn allow_spaces_after_header_name_in_responses(
         &mut self,
@@ -566,7 +581,7 @@ impl<'h, 'b> Request<'h, 'b> {
             &mut headers,
             &mut bytes,
             &HeaderParserConfig {
-                allow_spaces_after_header_name: false,
+                allow_spaces_after_header_name: config.allow_spaces_after_header_name_in_requests,
                 allow_obsolete_multiline_headers: false,
                 allow_space_before_first_header_name: config.allow_space_before_first_header_name,
                 ignore_invalid_headers: config.ignore_invalid_headers_in_requests

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,6 +274,11 @@ impl ParserConfig {
         self
     }
 
+    /// Whether spaces and tabs should be allowed after header names in responses.
+    pub fn spaces_after_header_name_in_responses_are_allowed(&self) -> bool {
+        self.allow_spaces_after_header_name_in_responses
+    }
+
     /// Sets whether multiple spaces are allowed as delimiters in request lines.
     ///
     /// # Background
@@ -352,12 +357,12 @@ impl ParserConfig {
         self
     }
 
-    /// Whether obsolete multiline headers should be allowed.
+    /// Whether obsolete multiline headers should be allowed in responses.
     pub fn obsolete_multiline_headers_in_responses_are_allowed(&self) -> bool {
         self.allow_obsolete_multiline_headers_in_responses
     }
 
-    /// Sets whether white space before the first header is allowed
+    /// Sets whether white space before the first header is allowed.
     ///
     /// This is not allowed by spec but some browsers ignore it. So this an option for
     /// compatibility.
@@ -447,6 +452,11 @@ impl ParserConfig {
         self
     }
 
+    /// Whether invalid header lines should be silently ignored in responses.
+    pub fn invalid_headers_in_responses_are_ignored(&self) -> bool {
+        self.ignore_invalid_headers_in_responses
+    }
+
     /// Sets whether invalid header lines should be silently ignored in requests.
     pub fn ignore_invalid_headers_in_requests(
         &mut self,
@@ -454,6 +464,11 @@ impl ParserConfig {
     ) -> &mut Self {
         self.ignore_invalid_headers_in_requests = value;
         self
+    }
+
+    /// Whether invalid header lines should be silently ignored in requests.
+    pub fn invalid_headers_in_requests_are_ignored(&self) -> bool {
+        self.ignore_invalid_headers_in_requests
     }
 
     /// Parses a response with the given config.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,56 +255,18 @@ impl<T> Status<T> {
 /// Parser configuration.
 #[derive(Clone, Debug, Default)]
 pub struct ParserConfig {
+    allow_multiple_spaces_in_request_line_delimiters: bool,
+    allow_multiple_spaces_in_response_status_delimiters: bool,
     allow_spaces_after_header_name_in_requests: bool,
     allow_spaces_after_header_name_in_responses: bool,
     allow_obsolete_multiline_headers_in_requests: bool,
     allow_obsolete_multiline_headers_in_responses: bool,
-    allow_multiple_spaces_in_request_line_delimiters: bool,
-    allow_multiple_spaces_in_response_status_delimiters: bool,
     allow_space_before_first_header_name: bool,
     ignore_invalid_headers_in_responses: bool,
     ignore_invalid_headers_in_requests: bool,
 }
 
 impl ParserConfig {
-    /// Sets whether spaces and tabs should be allowed after header names in requests and
-    /// responses.
-    pub fn allow_spaces_after_header_name(
-        &mut self,
-        value: bool,
-    ) -> &mut Self {
-        self.allow_spaces_after_header_name_in_requests(value)
-            .allow_spaces_after_header_name_in_responses(value)
-    }
-
-    /// Sets whether spaces and tabs should be allowed after header names in requests.
-    pub fn allow_spaces_after_header_name_in_requests(
-        &mut self,
-        value: bool,
-    ) -> &mut Self {
-        self.allow_spaces_after_header_name_in_requests = value;
-        self
-    }
-
-    /// Whether spaces and tabs should be allowed after header names in requests.
-    pub fn spaces_after_header_name_in_requests_are_allowed(&self) -> bool {
-        self.allow_spaces_after_header_name_in_requests
-    }
-
-    /// Sets whether spaces and tabs should be allowed after header names in responses.
-    pub fn allow_spaces_after_header_name_in_responses(
-        &mut self,
-        value: bool,
-    ) -> &mut Self {
-        self.allow_spaces_after_header_name_in_responses = value;
-        self
-    }
-
-    /// Whether spaces and tabs should be allowed after header names in responses.
-    pub fn spaces_after_header_name_in_responses_are_allowed(&self) -> bool {
-        self.allow_spaces_after_header_name_in_responses
-    }
-
     /// Sets whether multiple spaces are allowed as delimiters in start lines (request lines and
     /// response status lines).
     ///
@@ -369,6 +331,44 @@ impl ParserConfig {
     /// Whether multiple spaces are allowed as delimiters in response status lines.
     pub fn multiple_spaces_in_response_status_delimiters_are_allowed(&self) -> bool {
         self.allow_multiple_spaces_in_response_status_delimiters
+    }
+
+    /// Sets whether spaces and tabs should be allowed after header names in requests and
+    /// responses.
+    pub fn allow_spaces_after_header_name(
+        &mut self,
+        value: bool,
+    ) -> &mut Self {
+        self.allow_spaces_after_header_name_in_requests(value)
+            .allow_spaces_after_header_name_in_responses(value)
+    }
+
+    /// Sets whether spaces and tabs should be allowed after header names in requests.
+    pub fn allow_spaces_after_header_name_in_requests(
+        &mut self,
+        value: bool,
+    ) -> &mut Self {
+        self.allow_spaces_after_header_name_in_requests = value;
+        self
+    }
+
+    /// Whether spaces and tabs should be allowed after header names in requests.
+    pub fn spaces_after_header_name_in_requests_are_allowed(&self) -> bool {
+        self.allow_spaces_after_header_name_in_requests
+    }
+
+    /// Sets whether spaces and tabs should be allowed after header names in responses.
+    pub fn allow_spaces_after_header_name_in_responses(
+        &mut self,
+        value: bool,
+    ) -> &mut Self {
+        self.allow_spaces_after_header_name_in_responses = value;
+        self
+    }
+
+    /// Whether spaces and tabs should be allowed after header names in responses.
+    pub fn spaces_after_header_name_in_responses_are_allowed(&self) -> bool {
+        self.allow_spaces_after_header_name_in_responses
     }
 
     /// Sets whether obsolete multiline headers should be allowed in requests and responses.
@@ -507,25 +507,6 @@ impl ParserConfig {
         self.allow_space_before_first_header_name
     }
 
-    /// Parses a request with the given config.
-    pub fn parse_request<'buf>(
-        &self,
-        request: &mut Request<'_, 'buf>,
-        buf: &'buf [u8],
-    ) -> Result<usize> {
-        request.parse_with_config(buf, self)
-    }
-
-    /// Parses a request with the given config and buffer for headers
-    pub fn parse_request_with_uninit_headers<'headers, 'buf>(
-        &self,
-        request: &mut Request<'headers, 'buf>,
-        buf: &'buf [u8],
-        headers: &'headers mut [MaybeUninit<Header<'buf>>],
-    ) -> Result<usize> {
-        request.parse_with_config_and_uninit_headers(buf, self, headers)
-    }
-
     /// Sets whether invalid header lines should be silently ignored in requests and responses.
     ///
     /// This mimicks the behaviour of major browsers. You probably don't want this.
@@ -648,6 +629,25 @@ impl ParserConfig {
     /// Whether invalid header lines should be silently ignored in requests.
     pub fn invalid_headers_in_requests_are_ignored(&self) -> bool {
         self.ignore_invalid_headers_in_requests
+    }
+
+    /// Parses a request with the given config.
+    pub fn parse_request<'buf>(
+        &self,
+        request: &mut Request<'_, 'buf>,
+        buf: &'buf [u8],
+    ) -> Result<usize> {
+        request.parse_with_config(buf, self)
+    }
+
+    /// Parses a request with the given config and buffer for headers
+    pub fn parse_request_with_uninit_headers<'headers, 'buf>(
+        &self,
+        request: &mut Request<'headers, 'buf>,
+        buf: &'buf [u8],
+        headers: &'headers mut [MaybeUninit<Header<'buf>>],
+    ) -> Result<usize> {
+        request.parse_with_config_and_uninit_headers(buf, self, headers)
     }
 
     /// Parses a response with the given config.


### PR DESCRIPTION
Add missing `ParserConfig` accessors, convenience methods for configuring request and response parsing simultaneously, and request parsing options that bring request parsing configuration up to parity with response parsing configuration.