### PR TITLE
Test and fix a regression in parsing partial requests in the 1.9.x series

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1834,6 +1834,24 @@ mod tests {
         }
     }
 
+    /// Check all subset permutations of a partial request line with no headers
+    #[test]
+    fn partial_permutations() {
+        let req_str = "GET / HTTP/1.1\r\n\r\n";
+        let mut headers = [EMPTY_HEADER; NUM_OF_HEADERS];
+        let mut req = Request::new(&mut headers[..]);
+        for i in 0..req_str.len() {
+            let status = req.parse(req_str[..i].as_bytes());
+            assert_eq!(
+                status,
+                Ok(Status::Partial),
+                "partial request line should return partial. \
+                 Portion which failed: '{seg}' (below {i})",
+                seg = &req_str[..i]
+            );
+        }
+    }
+
     static RESPONSE_WITH_WHITESPACE_BETWEEN_HEADER_NAME_AND_COLON: &[u8] =
         b"HTTP/1.1 200 OK\r\nAccess-Control-Allow-Credentials : true\r\nBread: baguette\r\n\r\n";
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -955,12 +955,14 @@ fn parse_token<'a>(bytes: &mut Bytes<'a>) -> Result<&'a str> {
 pub fn parse_uri<'a>(bytes: &mut Bytes<'a>) -> Result<&'a str> {
     let start = bytes.pos();
     simd::match_uri_vectored(bytes);
-    // URI must have at least one char
-    if bytes.pos() == start {
-        return Err(Error::Token);
-    }
+    let end = bytes.pos();
 
     if next!(bytes) == b' ' {
+        // URI must have at least one char
+        if end == start {
+            return Err(Error::Token);
+        }
+
         return Ok(Status::Complete(
             // SAFETY: all bytes up till `i` must have been `is_token` and therefore also utf-8.
             unsafe { str::from_utf8_unchecked(bytes.slice_skip(1)) },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1547,6 +1547,34 @@ mod tests {
         }
     }
 
+    // A single byte which is part of a method is not invalid
+    req! {
+        test_request_one_byte_method,
+        b"G", Ok(Status::Partial),
+        |_req| {}
+    }
+
+    // A subset of a method is a partial method, not invalid
+    req! {
+        test_request_partial_method,
+        b"GE", Ok(Status::Partial),
+        |_req| {}
+    }
+
+    // A method, without the delimiting space, is a partial request
+    req! {
+        test_request_method_no_delimiter,
+        b"GET", Ok(Status::Partial),
+        |_req| {}
+    }
+
+    // Regression test: assert that a partial read with just the method and
+    // space results in a partial, rather than a token error from uri parsing.
+    req! {
+        test_request_method_only,
+        b"GET ", Ok(Status::Partial),
+        |_req| {}
+    }
 
     req! {
         test_request_partial,
@@ -1557,6 +1585,18 @@ mod tests {
     req! {
         test_request_partial_version,
         b"GET / HTTP/1.", Ok(Status::Partial),
+        |_req| {}
+    }
+
+    req! {
+        test_request_method_path_no_delimiter,
+        b"GET /", Ok(Status::Partial),
+        |_req| {}
+    }
+
+    req! {
+        test_request_method_path_only,
+        b"GET / ", Ok(Status::Partial),
         |_req| {}
     }
 


### PR DESCRIPTION
A regression was introduced [in this bit of the SWAR changeset](https://github.com/seanmonstar/httparse/pull/134/files#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L969-R882) which manifests as incorrectly classifying a `read()` with the contents `GET ` as a token error (because there's no characters yet to parse for the path part) rather than as an `Ok(Status::Partial)`.

This diff is three independent commits to:
1. Add specific regression tests covering this and similar situations
2. Add a general regression test checking all permutations of a partial one-line request
3. Fix the behavior of the `parse_uri()` function to disambiguate between an empty path followed by a space, versus a partial read that ends at the start of the path.

NB. This'll conflict with #175 — not in a material way, they'll work fine together, just a note.