### PR TITLE
perf: cibench workflow

### DIFF
--- a/.github/workflows/cibench.yml
+++ b/.github/workflows/cibench.yml
@@ -64,12 +64,18 @@ jobs:
       - name: Run benchmarks (master)
         run: |
           git checkout master
-          CARGO_CFG_HTTPARSE_DISABLE_SIMD=1 cargo bench --bench parse ${{ matrix.feature != 'swar' && format('--features httparse_simd,httparse_simd_target_feature_{0}', matrix.feature) || '' }} -- --save-baseline master-${{ matrix.feature }}
+          cargo bench --bench parse ${{ matrix.feature != 'swar' && format('--features httparse_simd') || '' }} -- --save-baseline master-${{ matrix.feature }}
+        env:
+          CARGO_CFG_HTTPARSE_DISABLE_SIMD: 1
+          RUSTFLAGS: ${{ matrix.feature != 'swar' && format('-C target-feature=+{0}', matrix.feature) || '' }}
 
       - name: Run benchmarks (PR)
         run: |
           git checkout ${{ github.event.pull_request.head.sha }}
-          CARGO_CFG_HTTPARSE_DISABLE_SIMD=1 cargo bench --bench parse ${{ matrix.feature != 'swar' && format('--features httparse_simd,httparse_simd_target_feature_{0}', matrix.feature) || '' }} -- --save-baseline pr-${{ matrix.feature }}-${{ github.event.pull_request.number }}
+          cargo bench --bench parse ${{ matrix.feature != 'swar' && format('--features httparse_simd') || '' }} -- --save-baseline pr-${{ matrix.feature }}-${{ github.event.pull_request.number }}
+        env:
+          CARGO_CFG_HTTPARSE_DISABLE_SIMD: 1
+          RUSTFLAGS: ${{ matrix.feature != 'swar' && format('-C target-feature=+{0}', matrix.feature) || '' }}
 
       - name: Compare benchmarks
         run: |
@@ -99,12 +105,18 @@ jobs:
       - name: Run benchmarks (master)
         run: |
           git checkout master
-          CARGO_CFG_HTTPARSE_DISABLE_SIMD=1 cargo bench --bench parse ${{ matrix.feature == 'neon' && '--features httparse_simd,httparse_simd_neon_intrinsics' || '' }} -- --save-baseline master-aarch64-${{ matrix.feature }}
+          cargo bench --bench parse ${{ matrix.feature == 'neon' && '--features httparse_simd' || '' }} -- --save-baseline master-aarch64-${{ matrix.feature }}
+        env:
+          CARGO_CFG_HTTPARSE_DISABLE_SIMD: 1
+          RUSTFLAGS: ${{ matrix.feature == 'neon' && '-C target-feature=+neon' || '' }}
 
       - name: Run benchmarks (PR)
         run: |
           git checkout ${{ github.event.pull_request.head.sha }}
-          CARGO_CFG_HTTPARSE_DISABLE_SIMD=1 cargo bench --bench parse ${{ matrix.feature == 'neon' && '--features httparse_simd,httparse_simd_neon_intrinsics' || '' }} -- --save-baseline pr-aarch64-${{ matrix.feature }}-${{ github.event.pull_request.number }}
+          cargo bench --bench parse ${{ matrix.feature == 'neon' && '--features httparse_simd' || '' }} -- --save-baseline pr-aarch64-${{ matrix.feature }}-${{ github.event.pull_request.number }}
+        env:
+          CARGO_CFG_HTTPARSE_DISABLE_SIMD: 1
+          RUSTFLAGS: ${{ matrix.feature == 'neon' && '-C target-feature=+neon' || '' }}
 
       - name: Compare benchmarks
         run: |

--- a/.github/workflows/cibench.yml
+++ b/.github/workflows/cibench.yml
@@ -64,17 +64,17 @@ jobs:
       - name: Run benchmarks (master)
         run: |
           git checkout master
-          cargo bench --bench parse ${{ matrix.feature != 'swar' && format('--features httparse_simd') || '' }} -- --save-baseline master-${{ matrix.feature }}
+          cargo bench --bench parse -- --save-baseline master-${{ matrix.feature }}
         env:
-          CARGO_CFG_HTTPARSE_DISABLE_SIMD: 1
+          CARGO_CFG_HTTPARSE_DISABLE_SIMD: ${{ matrix.feature == 'swar' && '1' || '0' }}
           RUSTFLAGS: ${{ matrix.feature != 'swar' && format('-C target-feature=+{0}', matrix.feature) || '' }}
 
       - name: Run benchmarks (PR)
         run: |
           git checkout ${{ github.event.pull_request.head.sha }}
-          cargo bench --bench parse ${{ matrix.feature != 'swar' && format('--features httparse_simd') || '' }} -- --save-baseline pr-${{ matrix.feature }}-${{ github.event.pull_request.number }}
+          cargo bench --bench parse -- --save-baseline pr-${{ matrix.feature }}-${{ github.event.pull_request.number }}
         env:
-          CARGO_CFG_HTTPARSE_DISABLE_SIMD: 1
+          CARGO_CFG_HTTPARSE_DISABLE_SIMD: ${{ matrix.feature == 'swar' && '1' || '0' }}
           RUSTFLAGS: ${{ matrix.feature != 'swar' && format('-C target-feature=+{0}', matrix.feature) || '' }}
 
       - name: Compare benchmarks
@@ -105,17 +105,17 @@ jobs:
       - name: Run benchmarks (master)
         run: |
           git checkout master
-          cargo bench --bench parse ${{ matrix.feature == 'neon' && '--features httparse_simd' || '' }} -- --save-baseline master-aarch64-${{ matrix.feature }}
+          cargo bench --bench parse -- --save-baseline master-aarch64-${{ matrix.feature }}
         env:
-          CARGO_CFG_HTTPARSE_DISABLE_SIMD: 1
+          CARGO_CFG_HTTPARSE_DISABLE_SIMD: ${{ matrix.feature == 'swar' && '1' || '0' }}
           RUSTFLAGS: ${{ matrix.feature == 'neon' && '-C target-feature=+neon' || '' }}
 
       - name: Run benchmarks (PR)
         run: |
           git checkout ${{ github.event.pull_request.head.sha }}
-          cargo bench --bench parse ${{ matrix.feature == 'neon' && '--features httparse_simd' || '' }} -- --save-baseline pr-aarch64-${{ matrix.feature }}-${{ github.event.pull_request.number }}
+          cargo bench --bench parse -- --save-baseline pr-aarch64-${{ matrix.feature }}-${{ github.event.pull_request.number }}
         env:
-          CARGO_CFG_HTTPARSE_DISABLE_SIMD: 1
+          CARGO_CFG_HTTPARSE_DISABLE_SIMD: ${{ matrix.feature == 'swar' && '1' || '0' }}
           RUSTFLAGS: ${{ matrix.feature == 'neon' && '-C target-feature=+neon' || '' }}
 
       - name: Compare benchmarks

--- a/.github/workflows/cibench.yml
+++ b/.github/workflows/cibench.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Compare benchmarks
         run: |
-          critcmp master pr-${{ github.event.pull_request.number }}
+          critcmp -t 5 master pr-${{ github.event.pull_request.number }}
 
   benchmark-x64:
     name: Run x64 benchmarks
@@ -79,7 +79,7 @@ jobs:
 
       - name: Compare benchmarks
         run: |
-          critcmp master-${{ matrix.feature }} pr-${{ matrix.feature }}-${{ github.event.pull_request.number }}
+          critcmp -t 5 master-${{ matrix.feature }} pr-${{ matrix.feature }}-${{ github.event.pull_request.number }}
 
   benchmark-aarch64:
     name: Run aarch64 benchmarks
@@ -120,4 +120,4 @@ jobs:
 
       - name: Compare benchmarks
         run: |
-          critcmp master-aarch64-${{ matrix.feature }} pr-aarch64-${{ matrix.feature }}-${{ github.event.pull_request.number }}
+          critcmp -t 5 master-aarch64-${{ matrix.feature }} pr-aarch64-${{ matrix.feature }}-${{ github.event.pull_request.number }}

--- a/.github/workflows/cibench.yml
+++ b/.github/workflows/cibench.yml
@@ -34,11 +34,11 @@ jobs:
       - name: Run benchmarks (PR)
         run: |
           git checkout ${{ github.event.pull_request.head.sha }}
-          cargo bench --bench parse -- --save-baseline pr-${{ github.event.pull_request.number }}
+          cargo bench --bench parse -- --save-baseline pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
 
       - name: Compare benchmarks
         run: |
-          critcmp -t 5 master pr-${{ github.event.pull_request.number }}
+          critcmp -t 5 master pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
 
   benchmark-x64:
     name: Run x64 benchmarks
@@ -72,14 +72,14 @@ jobs:
       - name: Run benchmarks (PR)
         run: |
           git checkout ${{ github.event.pull_request.head.sha }}
-          cargo bench --bench parse -- --save-baseline pr-${{ github.event.pull_request.number }}-${{ matrix.feature }}
+          cargo bench --bench parse -- --save-baseline pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}-${{ matrix.feature }}
         env:
           CARGO_CFG_HTTPARSE_DISABLE_SIMD: ${{ matrix.feature == 'swar' && '1' || '0' }}
           RUSTFLAGS: ${{ matrix.feature != 'swar' && format('-C target-feature=+{0}', matrix.feature) || '' }}
 
       - name: Compare benchmarks
         run: |
-          critcmp -t 5 master-${{ matrix.feature }} pr-${{ github.event.pull_request.number }}-${{ matrix.feature }}
+          critcmp -t 5 master-${{ matrix.feature }} pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}-${{ matrix.feature }}
 
   benchmark-aarch64:
     name: Run aarch64 benchmarks
@@ -113,11 +113,11 @@ jobs:
       - name: Run benchmarks (PR)
         run: |
           git checkout ${{ github.event.pull_request.head.sha }}
-          cargo bench --bench parse -- --save-baseline pr-${{ github.event.pull_request.number }}-aarch64-${{ matrix.feature }}
+          cargo bench --bench parse -- --save-baseline pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}-aarch64-${{ matrix.feature }}
         env:
           CARGO_CFG_HTTPARSE_DISABLE_SIMD: ${{ matrix.feature == 'swar' && '1' || '0' }}
           RUSTFLAGS: ${{ matrix.feature == 'neon' && '-C target-feature=+neon' || '' }}
 
       - name: Compare benchmarks
         run: |
-          critcmp -t 5 master-aarch64-${{ matrix.feature }} pr-${{ github.event.pull_request.number }}-aarch64-${{ matrix.feature }}
+          critcmp -t 5 master-aarch64-${{ matrix.feature }} pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}-aarch64-${{ matrix.feature }}

--- a/.github/workflows/cibench.yml
+++ b/.github/workflows/cibench.yml
@@ -72,14 +72,14 @@ jobs:
       - name: Run benchmarks (PR)
         run: |
           git checkout ${{ github.event.pull_request.head.sha }}
-          cargo bench --bench parse -- --save-baseline pr-${{ matrix.feature }}-${{ github.event.pull_request.number }}
+          cargo bench --bench parse -- --save-baseline pr-${{ github.event.pull_request.number }}-${{ matrix.feature }}
         env:
           CARGO_CFG_HTTPARSE_DISABLE_SIMD: ${{ matrix.feature == 'swar' && '1' || '0' }}
           RUSTFLAGS: ${{ matrix.feature != 'swar' && format('-C target-feature=+{0}', matrix.feature) || '' }}
 
       - name: Compare benchmarks
         run: |
-          critcmp -t 5 master-${{ matrix.feature }} pr-${{ matrix.feature }}-${{ github.event.pull_request.number }}
+          critcmp -t 5 master-${{ matrix.feature }} pr-${{ github.event.pull_request.number }}-${{ matrix.feature }}
 
   benchmark-aarch64:
     name: Run aarch64 benchmarks
@@ -113,11 +113,11 @@ jobs:
       - name: Run benchmarks (PR)
         run: |
           git checkout ${{ github.event.pull_request.head.sha }}
-          cargo bench --bench parse -- --save-baseline pr-aarch64-${{ matrix.feature }}-${{ github.event.pull_request.number }}
+          cargo bench --bench parse -- --save-baseline pr-${{ github.event.pull_request.number }}-aarch64-${{ matrix.feature }}
         env:
           CARGO_CFG_HTTPARSE_DISABLE_SIMD: ${{ matrix.feature == 'swar' && '1' || '0' }}
           RUSTFLAGS: ${{ matrix.feature == 'neon' && '-C target-feature=+neon' || '' }}
 
       - name: Compare benchmarks
         run: |
-          critcmp -t 5 master-aarch64-${{ matrix.feature }} pr-aarch64-${{ matrix.feature }}-${{ github.event.pull_request.number }}
+          critcmp -t 5 master-aarch64-${{ matrix.feature }} pr-${{ github.event.pull_request.number }}-aarch64-${{ matrix.feature }}

--- a/.github/workflows/cibench.yml
+++ b/.github/workflows/cibench.yml
@@ -34,14 +34,14 @@ jobs:
       - name: Run benchmarks (PR)
         run: |
           git checkout ${{ github.event.pull_request.head.sha }}
-          cargo bench --bench parse -- --save-baseline pr
+          cargo bench --bench parse -- --save-baseline pr-${{ github.event.pull_request.number }}
 
       - name: Compare benchmarks
         run: |
           critcmp master pr-${{ github.event.pull_request.number }}
 
-  benchmark-simd:
-    name: Run SIMD benchmarks
+  benchmark-x64:
+    name: Run x64 benchmarks
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -64,20 +64,23 @@ jobs:
       - name: Run benchmarks (master)
         run: |
           git checkout master
-          cargo bench --bench parse --features ${{ matrix.feature }} -- --save-baseline master-${{ matrix.feature }}
+          CARGO_CFG_HTTPARSE_DISABLE_SIMD=1 cargo bench --bench parse ${{ matrix.feature != 'swar' && format('--features httparse_simd,httparse_simd_target_feature_{0}', matrix.feature) || '' }} -- --save-baseline master-${{ matrix.feature }}
 
       - name: Run benchmarks (PR)
         run: |
           git checkout ${{ github.event.pull_request.head.sha }}
-          cargo bench --bench parse --features ${{ matrix.feature }} -- --save-baseline pr-${{ matrix.feature }}
+          CARGO_CFG_HTTPARSE_DISABLE_SIMD=1 cargo bench --bench parse ${{ matrix.feature != 'swar' && format('--features httparse_simd,httparse_simd_target_feature_{0}', matrix.feature) || '' }} -- --save-baseline pr-${{ matrix.feature }}-${{ github.event.pull_request.number }}
 
       - name: Compare benchmarks
         run: |
           critcmp master-${{ matrix.feature }} pr-${{ matrix.feature }}-${{ github.event.pull_request.number }}
 
   benchmark-aarch64:
-    name: Run aarch64/neon benchmarks
+    name: Run aarch64 benchmarks
     runs-on: macos-latest
+    strategy:
+      matrix:
+        feature: [swar, neon]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -96,13 +99,13 @@ jobs:
       - name: Run benchmarks (master)
         run: |
           git checkout master
-          cargo bench --bench parse --features neon -- --save-baseline master-aarch64
+          CARGO_CFG_HTTPARSE_DISABLE_SIMD=1 cargo bench --bench parse ${{ matrix.feature == 'neon' && '--features httparse_simd,httparse_simd_neon_intrinsics' || '' }} -- --save-baseline master-aarch64-${{ matrix.feature }}
 
       - name: Run benchmarks (PR)
         run: |
           git checkout ${{ github.event.pull_request.head.sha }}
-          cargo bench --bench parse --features neon -- --save-baseline pr-aarch64
+          CARGO_CFG_HTTPARSE_DISABLE_SIMD=1 cargo bench --bench parse ${{ matrix.feature == 'neon' && '--features httparse_simd,httparse_simd_neon_intrinsics' || '' }} -- --save-baseline pr-aarch64-${{ matrix.feature }}-${{ github.event.pull_request.number }}
 
       - name: Compare benchmarks
         run: |
-          critcmp master-aarch64 pr-aarch64-${{ github.event.pull_request.number }}
+          critcmp master-aarch64-${{ matrix.feature }} pr-aarch64-${{ matrix.feature }}-${{ github.event.pull_request.number }}

--- a/.github/workflows/cibench.yml
+++ b/.github/workflows/cibench.yml
@@ -1,0 +1,108 @@
+name: CI Benchmarks
+on:
+  pull_request:
+    branches: [master]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-C target-cpu=native"
+
+jobs:
+  benchmark:
+    name: Run benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Install critcmp
+        run: cargo install critcmp
+
+      - name: Run benchmarks (master)
+        run: |
+          git checkout master
+          cargo bench --bench parse -- --save-baseline master
+
+      - name: Run benchmarks (PR)
+        run: |
+          git checkout ${{ github.event.pull_request.head.sha }}
+          cargo bench --bench parse -- --save-baseline pr
+
+      - name: Compare benchmarks
+        run: |
+          critcmp master pr-${{ github.event.pull_request.number }}
+
+  benchmark-simd:
+    name: Run SIMD benchmarks
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        feature: [swar, sse42, avx2]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Install critcmp
+        run: cargo install critcmp
+
+      - name: Run benchmarks (master)
+        run: |
+          git checkout master
+          cargo bench --bench parse --features ${{ matrix.feature }} -- --save-baseline master-${{ matrix.feature }}
+
+      - name: Run benchmarks (PR)
+        run: |
+          git checkout ${{ github.event.pull_request.head.sha }}
+          cargo bench --bench parse --features ${{ matrix.feature }} -- --save-baseline pr-${{ matrix.feature }}
+
+      - name: Compare benchmarks
+        run: |
+          critcmp master-${{ matrix.feature }} pr-${{ matrix.feature }}-${{ github.event.pull_request.number }}
+
+  benchmark-aarch64:
+    name: Run aarch64/neon benchmarks
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Install critcmp
+        run: cargo install critcmp
+
+      - name: Run benchmarks (master)
+        run: |
+          git checkout master
+          cargo bench --bench parse --features neon -- --save-baseline master-aarch64
+
+      - name: Run benchmarks (PR)
+        run: |
+          git checkout ${{ github.event.pull_request.head.sha }}
+          cargo bench --bench parse --features neon -- --save-baseline pr-aarch64
+
+      - name: Compare benchmarks
+        run: |
+          critcmp master-aarch64 pr-aarch64-${{ github.event.pull_request.number }}


### PR DESCRIPTION
First pass at adding benchmarks in CI.
Covers matrix of key archs and SIMD extensions.
Outputs delta against `main` with `critcmp` (with 5% noise threshold).

### Future improvements
- Run classifier on results to indicate regression/improvement/neutral (aggregate or on specific arch)
- Post summary (or details if regression) as PR comment (didn't add cause without summary would be noisy)
- Could save `main` baselines as assets (and just ref/download them) instead of recomputing them for each PR
  (comes at a cost of statefulness and some adhoc complexity but would reduce CI time cost)

### Notes
- This adds CI (compute) time, but don't think it adds wall time since there are longer subtasks
- CI is still more noisy than controlled local env, but probably good enough for substantial perf changes and sanity-checking