### PR TITLE
perf(simd): avx2 fallback to swar instead of sse4.2

### DIFF
--- a/src/simd/avx2.rs
+++ b/src/simd/avx2.rs
@@ -1,7 +1,7 @@
 use crate::iter::Bytes;
 
 #[inline]
-#[target_feature(enable = "avx2", enable = "sse4.2")]
+#[target_feature(enable = "avx2")]
 pub unsafe fn match_uri_vectored(bytes: &mut Bytes) {
     while bytes.as_ref().len() >= 32 {
         let advance = match_url_char_32_avx(bytes.as_ref());
@@ -11,8 +11,8 @@ pub unsafe fn match_uri_vectored(bytes: &mut Bytes) {
             return;
         }
     }
-    // do both, since avx2 only works when bytes.len() >= 32
-    super::sse42::match_uri_vectored(bytes)
+    // NOTE: use SWAR for <32B, more efficient than falling back to SSE4.2
+    super::swar::match_uri_vectored(bytes)
 }
 
 #[inline(always)]
@@ -56,7 +56,7 @@ unsafe fn match_url_char_32_avx(buf: &[u8]) -> usize {
     r.trailing_zeros() as usize
 }
 
-#[target_feature(enable = "avx2", enable = "sse4.2")]
+#[target_feature(enable = "avx2")]
 pub unsafe fn match_header_value_vectored(bytes: &mut Bytes) {
     while bytes.as_ref().len() >= 32 {
         let advance = match_header_value_char_32_avx(bytes.as_ref());
@@ -66,8 +66,8 @@ pub unsafe fn match_header_value_vectored(bytes: &mut Bytes) {
             return;
         }
     }
-    // do both, since avx2 only works when bytes.len() >= 32
-    super::sse42::match_header_value_vectored(bytes)
+    // NOTE: use SWAR for <32B, more efficient than falling back to SSE4.2
+    super::swar::match_header_value_vectored(bytes)
 }
 
 #[inline(always)]


### PR DESCRIPTION
**TLDR:** 2-line change => 2x faster `req/req`
(doesn't raise the ceiling substantially but fixes perf issue of generic x64 build, using runtime dispatch)

This has massive implications on the default `simd::runtime::*` (x64 generic build) perf, improving how the code is lowered/inlined. (Falling back to SSE4.2 for a handful of bytes was wasteful).

Should supersede #175, #156

### Benchmarks on GH CodeSpace (4-core / 16GB)
(4 cores of a 64-core AMD EPYC 7763 host CPU)
```
> critcmp -t=5 main avx2swar
group                    avx2swar                               main
-----                    --------                               ----
header/count_001         1.00     21.8±3.10ns   349.2 MB/sec    6.14   134.0±11.80ns    56.9 MB/sec
header/count_002         1.00     31.9±4.18ns   418.7 MB/sec    7.95    253.5±8.07ns    52.7 MB/sec
header/count_004         1.00     49.8±4.39ns   498.2 MB/sec    10.08   501.9±4.58ns    49.4 MB/sec
header/count_008         1.00    94.1±15.11ns   506.8 MB/sec    7.04   662.1±15.47ns    72.0 MB/sec
header/count_016         1.00   186.2±21.89ns   501.9 MB/sec    3.95   735.3±12.50ns   127.1 MB/sec
header/count_032         1.00   349.9±37.92ns   528.7 MB/sec    2.58   902.5±28.32ns   205.0 MB/sec
header/count_064         1.00   655.4±29.35ns   561.7 MB/sec    2.02  1322.6±186.03ns   278.3 MB/sec
header/count_128         1.00  1281.6±66.01ns   573.0 MB/sec    1.43  1830.4±43.23ns   401.2 MB/sec
header/name_0001b        1.00     23.0±2.95ns   332.4 MB/sec    6.20   142.3±11.68ns    53.6 MB/sec
header/name_0002b        1.00     23.1±3.12ns   372.2 MB/sec    5.73    132.2±4.84ns    64.9 MB/sec
header/name_0004b        1.00     22.9±2.51ns   457.8 MB/sec    5.80    133.0±2.89ns    78.9 MB/sec
header/name_0008b        1.00     22.9±2.82ns   625.5 MB/sec    5.82    133.1±3.36ns   107.4 MB/sec
header/name_0016b        1.00     23.3±2.47ns   939.6 MB/sec    5.82    135.8±3.53ns   161.5 MB/sec
header/name_0032b        1.00     28.0±2.29ns  1327.5 MB/sec    5.00    140.0±4.22ns   265.6 MB/sec
header/name_0064b        1.00    44.8±11.81ns  1512.9 MB/sec    3.33    149.1±4.62ns   454.2 MB/sec
header/name_0128b        1.00     56.6±3.79ns     2.2 GB/sec    2.96    167.8±5.86ns   767.4 MB/sec
header/name_0256b        1.00     94.8±4.39ns     2.6 GB/sec    2.21   209.2±14.19ns  1198.8 MB/sec
header/name_0512b        1.00   182.7±10.37ns     2.6 GB/sec    1.62   296.5±27.59ns  1669.6 MB/sec
header/name_1024b        1.00   336.9±15.06ns     2.8 GB/sec    1.34   450.5±49.04ns     2.1 GB/sec
header/name_2048b        1.00   648.7±26.80ns     3.0 GB/sec    1.27  822.0±149.32ns     2.3 GB/sec
header/name_4096b        1.00  1280.2±78.67ns     3.0 GB/sec    1.06  1362.2±70.01ns     2.8 GB/sec
header/value_0001b       1.00     23.4±6.47ns   326.1 MB/sec    5.74    134.2±4.17ns    56.8 MB/sec
header/value_0002b       1.00     21.7±2.94ns   396.0 MB/sec    6.12    132.7±3.34ns    64.7 MB/sec
header/value_0004b       1.00     21.8±3.60ns   481.5 MB/sec    6.26    136.4±5.54ns    76.9 MB/sec
header/value_0008b       1.00     21.6±3.09ns   661.7 MB/sec    6.44   139.2±11.89ns   102.8 MB/sec
header/value_0016b       1.00     23.5±5.80ns   932.0 MB/sec    5.74    135.0±1.77ns   162.5 MB/sec
header/value_0064b       1.00     21.9±3.56ns     3.0 GB/sec    1.09     23.9±3.85ns     2.8 GB/sec
header/value_0128b       1.00     23.3±3.55ns     5.4 GB/sec    1.06     24.7±3.46ns     5.1 GB/sec
header/value_0512b       1.00    46.3±12.30ns    10.4 GB/sec    1.13    52.4±20.00ns     9.2 GB/sec
header/value_1024b       1.00     54.5±5.73ns    17.6 GB/sec    1.29    70.5±23.99ns    13.6 GB/sec
header/value_2048b       1.00     96.1±8.39ns    19.9 GB/sec    1.12    107.3±6.35ns    17.8 GB/sec
header/value_4096b       1.00   178.1±40.06ns    21.5 GB/sec    1.18   209.7±50.09ns    18.2 GB/sec
req/req                  1.00    168.5±6.15ns     4.0 GB/sec    1.94   327.5±70.03ns     2.0 GB/sec
req_short/req_short      1.00    63.7±15.68ns  1017.9 MB/sec    2.61    166.3±2.30ns   390.0 MB/sec
resp/resp                1.00    190.2±7.97ns     3.4 GB/sec    1.55    294.1±3.77ns     2.2 GB/sec
resp_short/resp_short    1.00     58.4±8.26ns  1485.9 MB/sec    2.86    167.3±1.67ns   518.7 MB/sec
uri/uri_0001b            1.00      6.3±0.64ns   303.4 MB/sec    18.62   117.1±1.01ns    16.3 MB/sec
uri/uri_0002b            1.00      7.3±1.16ns   391.7 MB/sec    16.19   118.3±1.67ns    24.2 MB/sec
uri/uri_0004b            1.00      9.3±0.40ns   512.3 MB/sec    13.12   122.1±3.56ns    39.0 MB/sec
uri/uri_0008b            1.00      5.9±0.22ns  1454.0 MB/sec    21.43  126.5±13.42ns    67.8 MB/sec
uri/uri_0016b            1.00      6.9±0.40ns     2.3 GB/sec    17.31   119.1±1.40ns   136.2 MB/sec
uri/uri_0032b            1.00      6.6±1.20ns     4.7 GB/sec    18.20   120.0±2.92ns   262.3 MB/sec
uri/uri_0064b            1.00      7.2±0.46ns     8.4 GB/sec    16.86   121.6±2.81ns   509.6 MB/sec
uri/uri_0128b            1.00      9.1±0.57ns    13.2 GB/sec    13.55   123.2±1.56ns   998.8 MB/sec
uri/uri_0256b            1.00     12.8±0.52ns    18.7 GB/sec    10.52   134.5±9.75ns  1821.9 MB/sec
uri/uri_0512b            1.00     20.2±1.11ns    23.6 GB/sec    6.88    139.2±3.70ns     3.4 GB/sec
uri/uri_1024b            1.00     35.4±2.58ns    26.9 GB/sec    4.60   163.0±18.05ns     5.9 GB/sec
uri/uri_2048b            1.00     65.4±4.08ns    29.2 GB/sec    3.15   205.7±18.82ns     9.3 GB/sec
uri/uri_4096b            1.00    132.1±8.96ns    28.9 GB/sec    2.26   299.2±55.29ns    12.8 GB/sec
version/http10           1.07      1.3±0.28ns     7.0 GB/sec    1.00      1.2±0.03ns     7.5 GB/sec
```