### PR TITLE
lint(simd): don't build simd::sse42 when +avx2

### DIFF
--- a/src/simd/mod.rs
+++ b/src/simd/mod.rs
@@ -15,6 +15,7 @@ pub use self::swar::*;
 
 #[cfg(all(
     httparse_simd,
+    not(httparse_simd_target_feature_avx2),
     any(
         target_arch = "x86",
         target_arch = "x86_64",


### PR DESCRIPTION
simd::avx2 no longer calls simd::sse42, so we shouldn't build it when compiling for +avx2
follow-up to #181 (didn't pay attention to warnings of unused code)