### PR TITLE
fix unsound use of pointer::add

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -45,7 +45,7 @@ impl<'a> Bytes<'a> {
     pub fn peek_ahead(&self, n: usize) -> Option<u8> {
         // SAFETY: obtain a potentially OOB pointer that is later compared against the `self.end`
         // pointer.
-        let ptr = unsafe { self.cursor.add(n) };
+        let ptr = self.cursor.wrapping_add(n);
         if ptr < self.end {
             // SAFETY: bounds checked pointer dereference is safe
             Some(unsafe { *ptr })


### PR DESCRIPTION
No functional changes intended.

From [the docs of pointer::add](https://doc.rust-lang.org/std/primitive.pointer.html#method.add): 
>If the computed offset is non-zero, then self must be derived from a pointer to some [allocated object](https://doc.rust-lang.org/std/ptr/index.html#allocated-object), and the entire memory range between self and the result must be in bounds of that allocated object. In particular, this range must not “wrap around” the edge of the address space.

