### PR TITLE
iter::slice_skip remove possibility of underflow in debug_assert

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -109,7 +109,7 @@ impl<'a> Bytes<'a> {
     /// implies a skip of at most 3).
     #[inline]
     pub unsafe fn slice_skip(&mut self, skip: usize) -> &'a [u8] {
-        debug_assert!(self.cursor.sub(skip) >= self.start);
+        debug_assert!(skip <= self.cursor.offset_from(self.start) as usize);
         let head = slice_from_ptr_range(self.start, self.cursor.sub(skip));
         self.commit();
         head


### PR DESCRIPTION
`self.cursor.sub(skip)` must point inside the allocation of this object or this is UB, not to mention the possibility that if `skip` is very large self.cursor.sub(skip) may underflow and fail to trigger the debug_assertion.