### PR TITLE
Fix method parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ std = []
 
 [dev-dependencies]
 criterion = "0.3.5"
+rand = "0.8.5"
 
 [lib]
 bench = false

--- a/src/simd/neon.rs
+++ b/src/simd/neon.rs
@@ -235,7 +235,7 @@ fn neon_code_matches_header_name_chars_table() {
     unsafe {
         assert!(byte_is_allowed(b'_', match_header_name_vectored));
 
-        for (b, allowed) in crate::HEADER_NAME_MAP.iter().cloned().enumerate() {
+        for (b, allowed) in crate::TOKEN_MAP.iter().cloned().enumerate() {
             assert_eq!(
                 byte_is_allowed(b as u8, match_header_name_vectored),
                 allowed,


### PR DESCRIPTION
The `is_token` function, used exclusively for parsing the method in a request line, allows more values than it should. In particular, it allows a leading space to be parsed.  This problem is not exposed in hyper, which revalidates any method extracted by httparse, otherwise I'm sure this would have been noticed sooner!

Checking for a single range of valid bytes is very fast, so I've taken care to make sure that making `is_token` more complicated doesn't slow down the most common case.  While exploring a variety of options, I found the existing benchmark scheme to be a bit misleading because it would test only a single method at a time, so I've made a new benchmark that roughly simulates a mix of requests.  Ultimately, what I found to be a reasonable fix without any slowdown for the 99.9999% case is to check `b'A'..=b'Z'` and then fall back to a "byte map".

Both methods and header names have the same set of allowed bytes, a "token", but their uses are slightly different. I thought it would make sense to rename `is_token` to `is_method_token`, to mimic `is_header_name_token`.