### PR TITLE
Update to use APIs up to MSRV

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -99,11 +99,11 @@ struct Version (u32, u32, u32);
 
 impl Version {
     fn parse(s: &str) -> Result<Version, String> {
-        if !s.starts_with("rustc ") {
-            return Err(format!("unrecognized version string: {}", s));
-        }
-        let s = s.trim_start_matches("rustc ");
-        
+        let s = match s.strip_prefix("rustc ") {
+            Some(s) => s,
+            None => return Err(format!("unrecognized version string: {}", s)),
+        };
+
         let mut iter = s
             .split('.')
             .take(3)

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -64,7 +64,7 @@ impl<'a> Bytes<'a> {
 
     #[inline]
     pub fn peek_n<'b: 'a, U: TryFrom<&'a [u8]>>(&'b self, n: usize) -> Option<U> {
-        // TODO: once we bump MSRC, use const generics to allow only [u8; N] reads
+        // TODO: once we bump MSRV, use const generics to allow only [u8; N] reads
         // TODO: drop `n` arg in favour of const
         // let n = core::mem::size_of::<U>();
         self.as_ref().get(..n)?.try_into().ok()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -757,21 +757,16 @@ pub const EMPTY_HEADER: Header<'static> = Header { name: "", value: b"" };
 // WARNING: Exported for internal benchmarks, not fit for public consumption
 pub fn parse_version(bytes: &mut Bytes) -> Result<u8> {
     if let Some(eight) = bytes.peek_n::<[u8; 8]>(8) {
-        // NOTE: should be const once MSRV >= 1.44
-        let h10: u64 = u64::from_ne_bytes(*b"HTTP/1.0");
-        let h11: u64 = u64::from_ne_bytes(*b"HTTP/1.1");
+        const H10: u64 = u64::from_ne_bytes(*b"HTTP/1.0");
+        const H11: u64 = u64::from_ne_bytes(*b"HTTP/1.1");
         // SAFETY: peek_n(8) before ensure within bounds
         unsafe {
             bytes.advance(8);
         }
-        let block = u64::from_ne_bytes(eight);
-        // NOTE: should be match once h10 & h11 are consts
-        return if block == h10 {
-            Ok(Status::Complete(0))
-        } else if block == h11 {
-            Ok(Status::Complete(1))
-        } else {
-            Err(Error::Version)
+        return match u64::from_ne_bytes(eight) {
+            H10 => Ok(Status::Complete(0)),
+            H11 => Ok(Status::Complete(1)),
+            _ => Err(Error::Version),
         };
     }
 

--- a/src/simd/avx2.rs
+++ b/src/simd/avx2.rs
@@ -74,10 +74,8 @@ unsafe fn match_url_char_32_avx(buf: &[u8]) -> usize {
     // Simply, we're converting a vector value to scalar value here.
     let res = _mm256_movemask_epi8(bit) as u32;
 
-    // Count trailing zeros to find the first encountered invalid character.
-    // Bitwise NOT is required once again to flip truthiness.
-    // TODO: use .trailing_ones() once MSRV >= 1.46
-    (!res).trailing_zeros() as usize
+    // Count trailing ones to find the first encountered invalid character.
+    res.trailing_ones() as usize
 }
 
 #[target_feature(enable = "avx2")]
@@ -138,10 +136,8 @@ unsafe fn match_header_value_char_32_avx(buf: &[u8]) -> usize {
     // Creates a scalar value from vector value.
     let res = _mm256_movemask_epi8(bit) as u32;
 
-    // Count trailing zeros to find the first encountered invalid character.
-    // Bitwise NOT is required once again to flip truthiness.
-    // TODO: use .trailing_ones() once MSRV >= 1.46
-    (!res).trailing_zeros() as usize
+    // Count trailing ones to find the first encountered invalid character.
+    res.trailing_ones() as usize
 }
 
 #[test]

--- a/src/simd/sse42.rs
+++ b/src/simd/sse42.rs
@@ -37,8 +37,7 @@ unsafe fn match_url_char_16_sse(buf: &[u8]) -> usize {
     let bit = _mm_andnot_si128(del, low);
     let res = _mm_movemask_epi8(bit) as u16;
 
-    // TODO: use .trailing_ones() once MSRV >= 1.46
-    (!res).trailing_zeros() as usize
+    res.trailing_ones() as usize
 }
 
 #[target_feature(enable = "sse4.2")]
@@ -79,8 +78,7 @@ unsafe fn match_header_value_char_16_sse(buf: &[u8]) -> usize {
     let bit = _mm_andnot_si128(del, _mm_or_si128(low, tab));
     let res = _mm_movemask_epi8(bit) as u16;
 
-    // TODO: use .trailing_ones() once MSRV >= 1.46
-    (!res).trailing_zeros() as usize
+    res.trailing_ones() as usize
 }
 
 #[test]

--- a/src/simd/swar.rs
+++ b/src/simd/swar.rs
@@ -103,10 +103,9 @@ fn match_block(f: impl Fn(u8) -> bool, block: ByteBlock) -> usize {
     BLOCK_SIZE
 }
 
-// A const alternative to u64::from_ne_bytes to avoid bumping MSRV (1.36 => 1.44)
 // creates a u64 whose bytes are each equal to b
 const fn uniform_block(b: u8) -> usize {
-    (b as u64 *  0x01_01_01_01_01_01_01_01 /* [1_u8; 8] */) as usize
+    usize::from_ne_bytes([b; BLOCK_SIZE])
 }
 
 // A byte-wise range-check on an entire word/block,


### PR DESCRIPTION
Update to use APIs which are available now that the [MSRV is 1.47](https://github.com/seanmonstar/httparse/pull/192):

- `{integer}::from_ne_bytes` const since 1.44
- `{integer}::trailing_ones` stable since 1.46
- `str::strip_prefix` stable since 1.45