### PR TITLE
refactor: use const generics from Rust 1.51

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,4 +1,3 @@
-use core::convert::TryFrom;
 use core::convert::TryInto;
 
 #[allow(missing_docs)]
@@ -63,11 +62,8 @@ impl<'a> Bytes<'a> {
     }
 
     #[inline]
-    pub fn peek_n<'b: 'a, U: TryFrom<&'a [u8]>>(&'b self, n: usize) -> Option<U> {
-        // TODO: once we bump MSRV, use const generics to allow only [u8; N] reads
-        // TODO: drop `n` arg in favour of const
-        // let n = core::mem::size_of::<U>();
-        self.as_ref().get(..n)?.try_into().ok()
+    pub fn peek_n<const N: usize>(&self) -> Option<[u8; N]> {
+        self.as_ref().get(..N)?.try_into().ok()
     }
 
     /// Advance by 1, equivalent to calling `advance(1)`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -762,10 +762,10 @@ pub const EMPTY_HEADER: Header<'static> = Header { name: "", value: b"" };
 #[allow(missing_docs)]
 // WARNING: Exported for internal benchmarks, not fit for public consumption
 pub fn parse_version(bytes: &mut Bytes) -> Result<u8> {
-    if let Some(eight) = bytes.peek_n::<[u8; 8]>(8) {
+    if let Some(eight) = bytes.peek_n::<8>() {
         const H10: u64 = u64::from_ne_bytes(*b"HTTP/1.0");
         const H11: u64 = u64::from_ne_bytes(*b"HTTP/1.1");
-        // SAFETY: peek_n(8) before ensure within bounds
+        // SAFETY: peek_n before ensures within bounds
         unsafe {
             bytes.advance(8);
         }
@@ -797,7 +797,7 @@ pub fn parse_version(bytes: &mut Bytes) -> Result<u8> {
 pub fn parse_method<'a>(bytes: &mut Bytes<'a>) -> Result<&'a str> {
     const GET: [u8; 4] = *b"GET ";
     const POST: [u8; 4] = *b"POST";
-    match bytes.peek_n::<[u8; 4]>(4) {
+    match bytes.peek_n::<4>() {
         Some(GET) => {
             // SAFETY: we matched "GET " which has 4 bytes and is ASCII
             let method = unsafe {

--- a/src/simd/swar.rs
+++ b/src/simd/swar.rs
@@ -9,7 +9,7 @@ type ByteBlock = [u8; BLOCK_SIZE];
 #[inline]
 pub fn match_uri_vectored(bytes: &mut Bytes) {
     loop {
-        if let Some(bytes8) = bytes.peek_n::<ByteBlock>(BLOCK_SIZE) {
+        if let Some(bytes8) = bytes.peek_n::<BLOCK_SIZE>() {
             let n = match_uri_char_8_swar(bytes8);
             // SAFETY: using peek_n to retrieve the bytes ensures that there are at least n more bytes
             // in `bytes`, so calling `advance(n)` is safe.
@@ -37,7 +37,7 @@ pub fn match_uri_vectored(bytes: &mut Bytes) {
 #[inline]
 pub fn match_header_value_vectored(bytes: &mut Bytes) {
     loop {
-        if let Some(bytes8) = bytes.peek_n::<ByteBlock>(BLOCK_SIZE) {
+        if let Some(bytes8) = bytes.peek_n::<BLOCK_SIZE>() {
             let n = match_header_value_char_8_swar(bytes8);
             // SAFETY: using peek_n to retrieve the bytes ensures that there are at least n more bytes
             // in `bytes`, so calling `advance(n)` is safe.
@@ -64,7 +64,7 @@ pub fn match_header_value_vectored(bytes: &mut Bytes) {
 
 #[inline]
 pub fn match_header_name_vectored(bytes: &mut Bytes) {
-    while let Some(block) = bytes.peek_n::<ByteBlock>(BLOCK_SIZE) {
+    while let Some(block) = bytes.peek_n::<BLOCK_SIZE>() {
         let n = match_block(is_header_name_token, block);
         // SAFETY: using peek_n to retrieve the bytes ensures that there are at least n more bytes
         // in `bytes`, so calling `advance(n)` is safe.


### PR DESCRIPTION
Fixes a TODO now that the MSRV has been bumped past Rust 1.51.