### PR TITLE
Fix whitespace-only header line silently truncating headers (fixes #222)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1102,6 +1102,16 @@ fn parse_headers_iter_uninit<'a>(
                             break;
                         }
                     }
+                    // A line consisting only of whitespace has no header to parse. Falling
+                    // through to `continue 'headers` here would let this loop's own CR/LF
+                    // check (above) treat it as the blank line terminating the header
+                    // section, silently discarding any real headers that follow in the
+                    // buffer.
+                    match bytes.peek() {
+                        None => return Ok(Status::Partial),
+                        Some(b'\r') | Some(b'\n') => break 'header Error::HeaderName,
+                        _ => {}
+                    }
                     bytes.slice();
                     continue 'headers;
                 } else {
@@ -2717,6 +2727,52 @@ mod tests {
         assert_eq!(response.headers.len(), 1);
         assert_eq!(response.headers[0].name, "Space-Before-Header");
         assert_eq!(response.headers[0].value, &b"hello there"[..]);
+    }
+
+    // Regression test: a line consisting only of whitespace (no header name/value follows before
+    // the line terminator) must not be silently treated as the blank line ending the header
+    // section -- that would discard every subsequent header from the parsed result while leaving
+    // their bytes unconsumed in the buffer for the caller to misinterpret as body/next-request
+    // data. This is the whitespace-only-line degenerate case that
+    // `test_allow_response_response_with_space_before_first_header` (above) never exercises, since
+    // its fixture always has real header content after the leading space.
+    #[test]
+    fn test_allow_space_before_first_header_name_rejects_whitespace_only_line() {
+        const REQUEST_WITH_WHITESPACE_ONLY_FIRST_LINE: &[u8] =
+            b"GET / HTTP/1.1\r\n \r\nHost: example.com\r\n\r\n";
+
+        let mut headers = [EMPTY_HEADER; 16];
+        let mut req = Request::new(&mut headers[..]);
+        let result = crate::ParserConfig::default()
+            .allow_space_before_first_header_name(true)
+            .parse_request(&mut req, REQUEST_WITH_WHITESPACE_ONLY_FIRST_LINE);
+
+        assert_eq!(result, Err(crate::Error::HeaderName));
+
+        const RESPONSE_WITH_WHITESPACE_ONLY_FIRST_LINE: &[u8] =
+            b"HTTP/1.1 200 OK\r\n \r\nContent-Length: 500\r\n\r\n";
+
+        let mut headers = [EMPTY_HEADER; 16];
+        let mut resp = Response::new(&mut headers[..]);
+        let result = crate::ParserConfig::default()
+            .allow_space_before_first_header_name(true)
+            .parse_response(&mut resp, RESPONSE_WITH_WHITESPACE_ONLY_FIRST_LINE);
+
+        assert_eq!(result, Err(crate::Error::HeaderName));
+    }
+
+    // The fix must not regress the streaming/incremental case: a buffer that ends right after the
+    // whitespace run (before the caller has fed the byte that would decide whitespace-only vs a
+    // real header) must return `Partial`, not error or complete prematurely.
+    #[test]
+    fn test_allow_space_before_first_header_name_partial_after_whitespace() {
+        let mut headers = [EMPTY_HEADER; 16];
+        let mut req = Request::new(&mut headers[..]);
+        let result = crate::ParserConfig::default()
+            .allow_space_before_first_header_name(true)
+            .parse_request(&mut req, b"GET / HTTP/1.1\r\n ");
+
+        assert_eq!(result, Ok(Status::Partial));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #222.

`ParserConfig::allow_space_before_first_header_name(true)` + a line consisting only of whitespace right
after the request/status-line silently dropped the entire header block: the parser returned
`Ok(Status::Complete)` with `headers == []`, leaving every real header (`Host`, `Content-Length`, ...)
unconsumed in the buffer.

### The fix

After stripping the leading whitespace run, peek at the next byte before deciding to continue:

```rust
match bytes.peek() {
    None => return Ok(Status::Partial),
    Some(b'\r') | Some(b'\n') => break 'header Error::HeaderName,
    _ => {}
}
```

- A whitespace-only line (next byte is `\r`/`\n`) now rejects with `Error::HeaderName` — the same error
  the non-leniency path already returns for a malformed first byte, rather than being silently absorbed
  as the terminating blank line.
- If there's no more data yet (`peek()` returns `None`), returns `Status::Partial` so the streaming/
  incremental case is unaffected — a caller that hasn't yet read the byte deciding whitespace-only vs. a
  real header isn't penalized.
- The documented, tested, non-degenerate case (space followed by a real header) is untouched.

### Tests added

- `test_allow_space_before_first_header_name_rejects_whitespace_only_line` — both request and response
  variants of the whitespace-only-line case now return `Err(HeaderName)` instead of silently truncating.
- `test_allow_space_before_first_header_name_partial_after_whitespace` — a buffer ending right after the
  whitespace run still returns `Status::Partial`, confirming the fix doesn't regress incremental parsing.

### Validation

- Full test suite: 99 → 101 tests, all green (`cargo test --release`).
- Existing `test_allow_response_response_with_space_before_first_header` (the documented non-degenerate
  case) unaffected.
- Manually re-verified both PoCs from the issue now return `Err(HeaderName)` instead of
  `Ok(Complete)`/`headers==[]`.

Found & fixed with the [rust-in-peace](https://github.com/scadastrangelove/rust-in-peace) security pipeline.
