### PR TITLE
Support all whitespace characters in header values

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ pub(crate) fn is_header_name_token(b: u8) -> bool {
 
 
 static HEADER_VALUE_MAP: [bool; 256] = byte_map!(
-    b'\t' | b' '..=0x7e | 0x80..=0xFF
+    b'\t' | b' '..=0x7e | 0x80..=0xFF | 0x0B..=0x0C
 );
 
 
@@ -2779,5 +2779,51 @@ mod tests {
         let result = crate::ParserConfig::default().parse_request(&mut request, b"GET /test?post=I\xE2msorryIforkedyou HTTP/1.1\r\nHost: example.org\r\n\r\n");
 
         assert_eq!(result, Err(crate::Error::Token));
+    }
+
+    static RESPONSE_WITH_VERTICAL_TAB_IN_HEADER: &[u8] =
+        b"HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Security-Policy: img-src http://example.com\x0Bhttp://example2.com;\r\n\r\n<html><body>Hello CSP</body></html>\n";
+
+    #[test]
+    fn test_vertical_tab_character_in_headers() {
+        let mut headers = [EMPTY_HEADER; 2];
+        let mut response = Response::new(&mut headers[..]);
+        let result = response.parse(RESPONSE_WITH_VERTICAL_TAB_IN_HEADER);
+
+        assert_eq!(
+            result,
+            Ok(Status::Complete(118))
+        );
+        assert_eq!(response.version.unwrap(), 1);
+        assert_eq!(response.code.unwrap(), 200);
+        assert_eq!(response.reason.unwrap(), "OK");
+        assert_eq!(response.headers.len(), 2);
+        assert_eq!(response.headers[0].name, "Content-Type");
+        assert_eq!(response.headers[0].value, &b"text/html"[..]);
+        assert_eq!(response.headers[1].name, "Content-Security-Policy");
+        assert_eq!(response.headers[1].value, &b"img-src http://example.com\x0Bhttp://example2.com;"[..]);
+    }
+
+    static RESPONSE_WITH_FORM_FEED_IN_HEADER: &[u8] =
+        b"HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Security-Policy: img-src http://example.com\x0Chttp://example2.com;\r\n\r\n<html><body>Hello CSP</body></html>\n";
+
+    #[test]
+    fn test_form_feed_character_in_headers() {
+        let mut headers = [EMPTY_HEADER; 2];
+        let mut response = Response::new(&mut headers[..]);
+        let result = response.parse(RESPONSE_WITH_FORM_FEED_IN_HEADER);
+
+        assert_eq!(
+            result,
+            Ok(Status::Complete(118))
+        );
+        assert_eq!(response.version.unwrap(), 1);
+        assert_eq!(response.code.unwrap(), 200);
+        assert_eq!(response.reason.unwrap(), "OK");
+        assert_eq!(response.headers.len(), 2);
+        assert_eq!(response.headers[0].name, "Content-Type");
+        assert_eq!(response.headers[0].value, &b"text/html"[..]);
+        assert_eq!(response.headers[1].name, "Content-Security-Policy");
+        assert_eq!(response.headers[1].value, &b"img-src http://example.com\x0Chttp://example2.com;"[..]);
     }
 }

--- a/src/simd/avx2.rs
+++ b/src/simd/avx2.rs
@@ -105,7 +105,11 @@ unsafe fn match_header_value_char_32_avx(buf: &[u8]) -> usize {
 
     let ptr = buf.as_ptr();
 
-    // %x09 %x20-%x7e %x80-%xff
+    // %x0B-%x0C %x09 %x20-%x7e %x80-%xff
+    // Create a vector full of horizontal tab (\v) (0x0B) characters.
+    let VERTICAL_TAB: __m256i = _mm256_set1_epi8(0x0B);
+    // Create a vector full of horizontal tab (\f) (0x0C) characters.
+    let FORM_FEED: __m256i = _mm256_set1_epi8(0x0C);
     // Create a vector full of horizontal tab (\t) (0x09) characters.
     let TAB: __m256i = _mm256_set1_epi8(0x09);
     // Create a vector full of DEL (0x7f) characters.
@@ -121,6 +125,10 @@ unsafe fn match_header_value_char_32_avx(buf: &[u8]) -> usize {
     // Same as what we do in `match_url_char_32_avx`.
     // This time the lower threshold is set to space character though.
     let low = _mm256_cmpeq_epi8(_mm256_max_epu8(dat, LOW), dat);
+    // Check if `dat` includes `FORM FEED` characters.
+    let form_feed = _mm256_cmpeq_epi8(dat, FORM_FEED);
+    // Check if `dat` includes `VERTICAL TAB` characters.
+    let vertical_tab = _mm256_cmpeq_epi8(dat, VERTICAL_TAB);
     // Check if `dat` includes `TAB` characters.
     let tab = _mm256_cmpeq_epi8(dat, TAB);
     // Check if `dat` includes `DEL` characters.
@@ -130,8 +138,8 @@ unsafe fn match_header_value_char_32_avx(buf: &[u8]) -> usize {
     // to connect `low` and `tab` but flip bits of `del`.
     //
     // In the end, this is simply:
-    // ~del & (low | tab)
-    let bit = _mm256_andnot_si256(del, _mm256_or_si256(low, tab));
+    // ~del & (low | form_feed | vertical_tab | tab)
+    let bit = _mm256_andnot_si256(del, _mm256_or_si256(low, _mm256_or_si256(form_feed, _mm256_or_si256(vertical_tab, tab))));
     // This creates a bitmask from the most significant bit of each byte.
     // Creates a scalar value from vector value.
     let res = _mm256_movemask_epi8(bit) as u32;

--- a/src/simd/neon.rs
+++ b/src/simd/neon.rs
@@ -20,7 +20,7 @@ pub fn match_header_name_vectored(bytes: &mut Bytes) {
 #[inline]
 pub fn match_header_value_vectored(bytes: &mut Bytes) {
     while bytes.as_ref().len() >= 16 {
-        // SAFETY: ensured that there are at least 16 bytes remaining 
+        // SAFETY: ensured that there are at least 16 bytes remaining
         unsafe {
             let advance = match_header_value_char_16_neon(bytes.as_ref().as_ptr());
             bytes.advance(advance);
@@ -142,9 +142,11 @@ unsafe fn match_header_value_char_16_neon(ptr: *const u8) -> usize {
     // Check that b' ' <= and b != 127 or b == 9
     let result = vcleq_u8(vdupq_n_u8(b' '), input);
 
-    // Allow tab
+    // Allow vertical tab, form feed and tab
+    let vertical_tab = vceqq_u8(input, vdupq_n_u8(0x0B));
+    let form_feed = vceqq_u8(input, vdupq_n_u8(0x0C));
     let tab = vceqq_u8(input, vdupq_n_u8(0x09));
-    let result = vorrq_u8(result, tab);
+    let result = vorrq_u8(result, vorrq_u8(form_feed, vorrq_u8(vertical_tab, tab)));
 
     // Disallow del
     let del = vceqq_u8(input, vdupq_n_u8(0x7F));

--- a/src/simd/sse42.rs
+++ b/src/simd/sse42.rs
@@ -65,7 +65,9 @@ unsafe fn match_header_value_char_16_sse(buf: &[u8]) -> usize {
 
     let ptr = buf.as_ptr();
 
-    // %x09 %x20-%x7e %x80-%xff
+    // %x0B-%x0C %x09 %x20-%x7e %x80-%xff
+    let VERTICAL_TAB: __m128i = _mm_set1_epi8(0x0B);
+    let FORM_FEED: __m128i = _mm_set1_epi8(0x0C);
     let TAB: __m128i = _mm_set1_epi8(0x09);
     let DEL: __m128i = _mm_set1_epi8(0x7f);
     let LOW: __m128i = _mm_set1_epi8(0x20);
@@ -73,9 +75,11 @@ unsafe fn match_header_value_char_16_sse(buf: &[u8]) -> usize {
     let dat = _mm_lddqu_si128(ptr as *const _);
     // unsigned comparison dat >= LOW
     let low = _mm_cmpeq_epi8(_mm_max_epu8(dat, LOW), dat);
+    let vertical_tab = _mm_cmpeq_epi8(dat, VERTICAL_TAB);
+    let form_feed = _mm_cmpeq_epi8(dat, FORM_FEED);
     let tab = _mm_cmpeq_epi8(dat, TAB);
     let del = _mm_cmpeq_epi8(dat, DEL);
-    let bit = _mm_andnot_si128(del, _mm_or_si128(low, tab));
+    let bit = _mm_andnot_si128(del, _mm_or_si128(low, _mm_or_si128(form_feed, _mm_or_si128(vertical_tab, tab))));
     let res = _mm_movemask_epi8(bit) as u16;
 
     res.trailing_ones() as usize


### PR DESCRIPTION
This PR is part of a series of PRs across several crates, to eventually fix web-platform-test failures for Servo.

Servo currently fails [`/content-security-policy/generic/only-valid-whitespaces-are-allowed.html`](https://wpt.fyi/results/content-security-policy/generic/only-valid-whitespaces-are-allowed.html?product=servo) which is a test that checks whether various whitespace characters are properly parsed in the `Content-Security-Policy` header.

Currently, Servo times out on this test, since it attempts to send a HTTP request with Hyper. Hyper calls `httparse` to parse the response returned by the test server with, which includes the `Content-Security-Policy` with the special whitespace character. When `httparse` attempts to parse this, it fails since it contains characters it currently does not accept.

While RFC7230 (HTTP) does not allow such characters to be present, for web browsers [section 3.5](https://datatracker.ietf.org/doc/html/rfc7230#section-3.5) is relevant. That section states that for historical reasons (which is the case for web browsers), both `%x0B` and `%x0C` MAY be treated as regular space characters.

Since currently `httparse` rejects parsing, Servo is unable to implement that requirement. To fix this issue, the following changes are made:

1. In `httparse`, support parsing `%x0B` and `%x0C` in header values (https://github.com/seanmonstar/httparse/pull/225)
2. In `http`, consider `%x0B` and `%x0C` as opaque bytes for byte constructors (https://github.com/hyperium/http/pull/862)
3. In `hyper`, use `HeaderValue::from_bytes` rather than the generic `HeaderValue::from_maybe_shared_unchecked` to operate on the raw bytes (https://github.com/hyperium/hyper/pull/4155)
4. In `content-security-policy` update policy parsing to check if directive value is an ASCII string. It already handles `%x0B` and `%x0C` in `is_char_ascii_whitespace`, but with the HTTP changes it exposed this other missing check (https://github.com/rust-ammonia/rust-content-security-policy/pull/74)
5. In Servo, replace `header.to_str()` with `str::from_utf8(header.as_bytes())` (https://github.com/servo/servo/pull/47194)